### PR TITLE
Generalization of `parse!` and improvements

### DIFF
--- a/src/buffer/slice.rs
+++ b/src/buffer/slice.rs
@@ -16,7 +16,7 @@ use buffer::{IntoStream, StreamError, Stream};
 ///
 /// let r = i.into_stream().parse(parser!{
 ///     token(b'f');
-///     take(2);
+///     take(2)
 /// });
 ///
 /// assert_eq!(r, Ok(b"oo" as &[u8]));
@@ -33,7 +33,7 @@ use buffer::{IntoStream, StreamError, Stream};
 ///
 /// let r = i.into_stream().parse(parser!{many(parser!{
 ///     token(b'f');
-///     take(2);
+///     take(2)
 /// })});
 ///
 /// assert_eq!(r, Ok(vec![b"oo" as &[u8], b"oo" as &[u8]]));

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -70,6 +70,9 @@ pub fn option<'a, I, T, E, F>(i: Input<'a, I>, f: F, default: T) -> ParseResult<
 ///
 /// Incomplete state is propagated from the first one to report incomplete.
 ///
+/// If multiple `or` combinators are used in the same expression, consider using the `parse!` macro
+/// and its alternation operator (`<|>`).
+///
 #[cfg_attr(feature = "verbose_error", doc = "
 ```
  use chomp::{ParseError, Error, parse_only, or, token};

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -157,7 +157,24 @@ macro_rules! __parse_internal {
     ( @STATEMENT($args:tt $($data:tt)*) )                    => { __parse_internal!{ @BIND($args $($data)*) } };
     ( @STATEMENT($args:tt $($data:tt)*) ; $($tail:tt)*)      => { __parse_internal!{ @BIND($args $($data)*) $($tail)*} };
     // Recurse to eat until ; or end
-    ( @STATEMENT($args:tt $($data:tt)*) $t:tt $($tail:tt)* ) => { __parse_internal!{@STATEMENT($args $($data)* $t) $($tail)*} };
+    // Technically could just use a single pattern for this recursion:
+    // ( @STATEMENT($args:tt $($data:tt)*) $t:tt $($tail:tt)* ) => { __parse_internal!{@STATEMENT($args $($data)* $t) $($tail)*} };
+    // But to avoid the recursion limit somewhat we have explicit cases for up to 7 tokens before ; or end:
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt ) => { __parse_internal!{ @BIND($args $($data)* $t1) } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1) $($tail)* } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2) } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2) $($tail)* } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3) } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3) $($tail)* } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4) } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4) $($tail)* } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4 $t5) } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4 $t5) $($tail)* } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6) } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6) $($tail)* } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt ) => { __parse_internal!{ @STATEMENT($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7) } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7) $($tail)* } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt $($tail:tt)* ) => { __parse_internal!{ @STATEMENT($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8) $($tail)* } };
 
     // Statement ::= Bind ';'
     //             | Expr ';'

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -587,16 +587,12 @@ macro_rules! __parse_internal {
 
 /// Macro wrapping an invocation to ``parse!`` in a closure, useful for creating parsers inline.
 ///
-/// This makes it easier to eg. implement branching in the same ``parse!`` block:
-///
 /// ```
 /// # #[macro_use] extern crate chomp;
 /// # fn main() {
-/// use chomp::{parse_only, or, string};
+/// use chomp::{parse_only, string};
 ///
-/// let r = parser!{
-///   or(parser!{string(b"ab")},
-///      parser!{string(b"ac")})};
+/// let r = parser!{ string(b"ab") <|> string(b"ac") };
 ///
 /// assert_eq!(parse_only(r, b"ac"), Ok(&b"ac"[..]));
 /// # }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,6 +15,8 @@
 ///
 /// # Examples
 ///
+/// Parsing into a struct using the basic provided parsers:
+///
 /// ```
 /// # #[macro_use] extern crate chomp;
 /// # fn main() {
@@ -45,6 +47,9 @@
 /// # }
 /// ```
 ///
+/// Parsing an IP-address with a string-prefix and terminated with semicolon using the `<*` (skip)
+/// operator to make it more succint:
+///
 /// ```
 /// # #[macro_use] extern crate chomp;
 /// # fn main() {
@@ -66,6 +71,8 @@
 /// assert_eq!(parse_only(parse_ip, b"ip:192.168.0.1;"), Ok((192, 168, 0, 1)));
 /// # }
 /// ```
+///
+/// Parsing a log-level using the `<|>` alternation (or) operator:
 ///
 /// ```
 /// # #[macro_use] extern crate chomp;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -171,7 +171,7 @@ macro_rules! __parse_internal {
     ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt ; $($tail:tt)* )                    => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5) $($tail)*} };
     ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt )                            => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6)} };
     ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt ; $($tail:tt)* )             => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6) $($tail)*} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt )                     => { __parse_internal!{@STATEMENT($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt )                     => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7)} };
     ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt ; $($tail:tt)* )      => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7) $($tail)*} };
     ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt $($tail:tt)* ) => { __parse_internal!{@STATEMENT($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8) $($tail)*} };
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -67,6 +67,31 @@
 /// # }
 /// ```
 ///
+/// ```
+/// # #[macro_use] extern crate chomp;
+/// # fn main() {
+/// use chomp::{parse_only, string};
+///
+/// #[derive(Debug, Eq, PartialEq)]
+/// enum Log {
+///     Error,
+///     Warning,
+///     Info,
+///     Debug,
+/// };
+///
+/// let level        = |i, b, r| string(i, b).map(|_| r);
+/// let log_severity = parser!{
+///     level(b"WARN",  Log::Warning) <|>
+///     level(b"INFO",  Log::Info)    <|>
+///     level(b"ERROR", Log::Error)   <|>
+///     level(b"DEBUG", Log::Debug)
+/// };
+///
+/// assert_eq!(parse_only(log_severity, b"INFO"), Ok(Log::Info));
+/// # }
+/// ```
+///
 /// # Grammar
 ///
 /// EBNF using `$ty`, `$expr`, `$ident` and `$pat` for the equivalent Rust macro patterns.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -132,48 +132,48 @@ macro_rules! __parse_internal {
 
     // EXPR groups by lowest priority item first which is then ">>"
     // Expr ::= ExprAlt
-    ( @EXPR($input:expr; $($lhs:tt)*) )                     => { __parse_internal!{@EXPR_ALT($input;) $($lhs)*} };
+    ( @EXPR($input:expr; $($lhs:tt)*) )                          => { __parse_internal!{@EXPR_ALT($input;) $($lhs)*} };
     //        | ExprAlt ">>" Expr
-    ( @EXPR($input:expr; $($lhs:tt)*) >> $($tail:tt)* )     => { __parse_internal!{@EXPR_ALT($input;) $($lhs)*}.bind(|i, _| __parse_internal!{@EXPR(i;) $($tail)*}) };
+    ( @EXPR($input:expr; $($lhs:tt)*) >> $($tail:tt)* )          => { __parse_internal!{@EXPR_ALT($input;) $($lhs)*}.bind(|i, _| __parse_internal!{@EXPR(i;) $($tail)*}) };
     // recurse until >> or end
-    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $($tail:tt)* ) => { __parse_internal!{ @EXPR($input; $($lhs)* $t1) $($tail)* } };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $($tail:tt)* )      => { __parse_internal!{@EXPR($input; $($lhs)* $t1) $($tail)*} };
 
     // ExprAlt ::= ExprSkip
-    ( @EXPR_ALT($input:expr; $($lhs:tt)*) )                     => { __parse_internal!{@EXPR_SKIP($input;) $($lhs)*} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) )                      => { __parse_internal!{@EXPR_SKIP($input;) $($lhs)*} };
     //           | ExprSkip <|> ExprAlt
-    ( @EXPR_ALT($input:expr; $($lhs:tt)*) <|> $($tail:tt)* )    => { __parse_internal_or!{$input, |i| __parse_internal!{@EXPR_SKIP(i;) $($lhs)*}, |i| __parse_internal!{@EXPR_ALT(i;) $($tail)*}} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) <|> $($tail:tt)* )     => { __parse_internal_or!{$input, |i| __parse_internal!{@EXPR_SKIP(i;) $($lhs)*}, |i| __parse_internal!{@EXPR_ALT(i;) $($tail)*}} };
     // recurse until <|> or end
-    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $($tail:tt)* ) => { __parse_internal!{ @EXPR_ALT($input; $($lhs)* $t1) $($tail)* } };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $($tail:tt)* )  => { __parse_internal!{@EXPR_ALT($input; $($lhs)* $t1) $($tail)*} };
 
     // ExprSkip ::= Term
     ( @EXPR_SKIP($input:expr; $($lhs:tt)*) )                     => { __parse_internal!{@TERM($input) $($lhs)*} };
     //            | Term <* ExprSkip
     ( @EXPR_SKIP($input:expr; $($lhs:tt)*) <* $($tail:tt)* )     => { __parse_internal!{@TERM($input) $($lhs)*}.bind(|i, l| __parse_internal!{@EXPR_SKIP(i;) $($tail)*}.map(|_| l)) };
     // recurse until <|> or end
-    ( @EXPR_SKIP($input:expr; $($lhs:tt)*) $t1:tt $($tail:tt)* ) => { __parse_internal!{ @EXPR_SKIP($input; $($lhs)* $t1) $($tail)* } };
+    ( @EXPR_SKIP($input:expr; $($lhs:tt)*) $t1:tt $($tail:tt)* ) => { __parse_internal!{@EXPR_SKIP($input; $($lhs)* $t1) $($tail)*} };
 
     // STATEMENT eats and groups a full parse! expression until the next ;
-    ( @STATEMENT($args:tt $($data:tt)*) )                    => { __parse_internal!{ @BIND($args $($data)*) } };
-    ( @STATEMENT($args:tt $($data:tt)*) ; $($tail:tt)*)      => { __parse_internal!{ @BIND($args $($data)*) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) )                        => { __parse_internal!{@BIND($args $($data)*)} };
+    ( @STATEMENT($args:tt $($data:tt)*) ; $($tail:tt)*)          => { __parse_internal!{@BIND($args $($data)*) $($tail)*} };
     // Recurse to eat until ; or end
     // Technically could just use a single pattern for this recursion:
     // ( @STATEMENT($args:tt $($data:tt)*) $t:tt $($tail:tt)* ) => { __parse_internal!{@STATEMENT($args $($data)* $t) $($tail)*} };
     // But to avoid the recursion limit somewhat we have explicit cases for up to 7 tokens before ; or end:
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt ) => { __parse_internal!{ @BIND($args $($data)* $t1) } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1) $($tail)* } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2) } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2) $($tail)* } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3) } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3) $($tail)* } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4) } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4) $($tail)* } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4 $t5) } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4 $t5) $($tail)* } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6) } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6) $($tail)* } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt ) => { __parse_internal!{ @STATEMENT($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7) } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt ; $($tail:tt)* ) => { __parse_internal!{ @BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7) $($tail)* } };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt $($tail:tt)* ) => { __parse_internal!{ @STATEMENT($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8) $($tail)* } };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt )                                                               => { __parse_internal!{@BIND($args $($data)* $t1)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt ; $($tail:tt)* )                                                => { __parse_internal!{@BIND($args $($data)* $t1) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt )                                                        => { __parse_internal!{@BIND($args $($data)* $t1 $t2)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt ; $($tail:tt)* )                                         => { __parse_internal!{@BIND($args $($data)* $t1 $t2) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt )                                                 => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt ; $($tail:tt)* )                                  => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt )                                          => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt ; $($tail:tt)* )                           => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt )                                   => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt ; $($tail:tt)* )                    => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt )                            => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt ; $($tail:tt)* )             => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt )                     => { __parse_internal!{@STATEMENT($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt ; $($tail:tt)* )      => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt $($tail:tt)* ) => { __parse_internal!{@STATEMENT($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8) $($tail)*} };
 
     // Statement ::= Bind ';'
     //             | Expr ';'

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -100,8 +100,9 @@ macro_rules! __parse_internal {
     // Internal rules
 
     // BIND ties an expression together with the following statement
-    // The four versions are needed to allow $pat, $ident:$ty, _ and the empty case
-    ( @BIND(($input:expr ; $($var:tt)*)               $($exp:tt)+)              ) => { __parse_internal!{@EXPR($input) $($exp)* } };
+    // The four versions are needed to allow $pat, $ident:$ty, _ and the empty case (no tailing
+    // allowed on the empty case)
+    ( @BIND(($input:expr ; _)                         $($exp:tt)+) )              => { __parse_internal!{@EXPR($input) $($exp)* } };
     ( @BIND(($input:expr ; _)                         $($exp:tt)+) $($tail:tt)+ ) => { __parse_internal!{@EXPR($input) $($exp)* }.bind(|i, _| __parse_internal!{i; $($tail)* }) };
     ( @BIND(($input:expr ; $name:pat)                 $($exp:tt)+) $($tail:tt)+ ) => { __parse_internal!{@EXPR($input) $($exp)* }.bind(|i, $name| __parse_internal!{i; $($tail)* }) };
     ( @BIND(($input:expr ; $name:ident : $name_ty:ty) $($exp:tt)+) $($tail:tt)+ ) => { __parse_internal!{@EXPR($input) $($exp)* }.bind(|i, $name : $name_ty| __parse_internal!{i; $($tail)* }) };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -319,21 +319,63 @@ macro_rules! __parse_internal {
     //        | ExprAlt ">>" Expr
     ( @EXPR($input:expr; $($lhs:tt)*) >> $($tail:tt)* )          => { __parse_internal!{@EXPR_ALT($input;) $($lhs)*}.bind(|i, _| __parse_internal!{@EXPR(i;) $($tail)*}) };
     // recurse until >> or end
-    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $($tail:tt)* )      => { __parse_internal!{@EXPR($input; $($lhs)* $t1) $($tail)*} };
+    // unrolled:
+    // ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $($tail:tt)* )      => { __parse_internal!{@EXPR($input; $($lhs)* $t1) $($tail)*} };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt )                                                               => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1} };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt >> $($tail:tt)* )                                               => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1}.bind(|i, _| __parse_internal!{@EXPR(i;) $($tail)*}) };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $t2:tt )                                                        => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1 $t2} };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $t2:tt >> $($tail:tt)* )                                        => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1 $t2}.bind(|i, _| __parse_internal!{@EXPR(i;) $($tail)*}) };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt )                                                 => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1 $t2 $t3} };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt >> $($tail:tt)* )                                 => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1 $t2 $t3}.bind(|i, _| __parse_internal!{@EXPR(i;) $($tail)*}) };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt )                                          => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1 $t2 $t3 $t4} };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt >> $($tail:tt)* )                          => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1 $t2 $t3 $t4}.bind(|i, _| __parse_internal!{@EXPR(i;) $($tail)*}) };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt )                                   => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1 $t2 $t3 $t4 $t5} };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt >> $($tail:tt)* )                   => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1 $t2 $t3 $t4 $t5}.bind(|i, _| __parse_internal!{@EXPR(i;) $($tail)*}) };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt )                            => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1 $t2 $t3 $t4 $t5 $t6} };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt >> $($tail:tt)* )            => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1 $t2 $t3 $t4 $t5 $t6}.bind(|i, _| __parse_internal!{@EXPR(i;) $($tail)*}) };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt )                     => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1 $t2 $t3 $t4 $t5 $t6 $t7} };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt >> $($tail:tt)* )     => { __parse_internal!{@EXPR_ALT($input;) $($lhs)* $t1 $t2 $t3 $t4 $t5 $t6 $t7}.bind(|i, _| __parse_internal!{@EXPR(i;) $($tail)*}) };
+    ( @EXPR($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt $($tail:tt)* ) => { __parse_internal!{@EXPR($input; $($lhs)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8) $($tail)*} };
 
     // ExprAlt ::= ExprSkip
     ( @EXPR_ALT($input:expr; $($lhs:tt)*) )                      => { __parse_internal!{@EXPR_SKIP($input;) $($lhs)*} };
     //           | ExprSkip <|> ExprAlt
     ( @EXPR_ALT($input:expr; $($lhs:tt)*) <|> $($tail:tt)* )     => { __parse_internal_or!{$input, |i| __parse_internal!{@EXPR_SKIP(i;) $($lhs)*}, |i| __parse_internal!{@EXPR_ALT(i;) $($tail)*}} };
     // recurse until <|> or end
-    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $($tail:tt)* )  => { __parse_internal!{@EXPR_ALT($input; $($lhs)* $t1) $($tail)*} };
+    // unrolled:
+    // ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $($tail:tt)* )  => { __parse_internal!{@EXPR_ALT($input; $($lhs)* $t1) $($tail)*} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt )                                                               => { __parse_internal!{@EXPR_SKIP($input;) $($lhs)* $t1} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt <|> $($tail:tt)* )                                              => { __parse_internal_or!{$input, |i| __parse_internal!{@EXPR_SKIP(i;) $($lhs)* $t1}, |i| __parse_internal!{@EXPR_ALT(i;) $($tail)*}} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $t2:tt )                                                        => { __parse_internal!{@EXPR_SKIP($input;) $($lhs)* $t1 $t2} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $t2:tt <|> $($tail:tt)* )                                       => { __parse_internal_or!{$input, |i| __parse_internal!{@EXPR_SKIP(i;) $($lhs)* $t1 $t2}, |i| __parse_internal!{@EXPR_ALT(i;) $($tail)*}} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt )                                                 => { __parse_internal!{@EXPR_SKIP($input;) $($lhs)* $t1 $t2 $t3} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt <|> $($tail:tt)* )                                => { __parse_internal_or!{$input, |i| __parse_internal!{@EXPR_SKIP(i;) $($lhs)* $t1 $t2 $t3}, |i| __parse_internal!{@EXPR_ALT(i;) $($tail)*}} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt )                                          => { __parse_internal!{@EXPR_SKIP($input;) $($lhs)* $t1 $t2 $t3 $t4} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt <|> $($tail:tt)* )                         => { __parse_internal_or!{$input, |i| __parse_internal!{@EXPR_SKIP(i;) $($lhs)* $t1 $t2 $t3 $t4}, |i| __parse_internal!{@EXPR_ALT(i;) $($tail)*}} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt )                                   => { __parse_internal!{@EXPR_SKIP($input;) $($lhs)* $t1 $t2 $t3 $t4 $t5} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt <|> $($tail:tt)* )                  => { __parse_internal_or!{$input, |i| __parse_internal!{@EXPR_SKIP(i;) $($lhs)* $t1 $t2 $t3 $t4 $t5}, |i| __parse_internal!{@EXPR_ALT(i;) $($tail)*}} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt )                            => { __parse_internal!{@EXPR_SKIP($input;) $($lhs)* $t1 $t2 $t3 $t4 $t5 $t6} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt <|> $($tail:tt)* )           => { __parse_internal_or!{$input, |i| __parse_internal!{@EXPR_SKIP(i;) $($lhs)* $t1 $t2 $t3 $t4 $t5 $t6}, |i| __parse_internal!{@EXPR_ALT(i;) $($tail)*}} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt )                     => { __parse_internal!{@EXPR_SKIP($input;) $($lhs)* $t1 $t2 $t3 $t4 $t5 $t6 $t7} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt <|> $($tail:tt)* )    => { __parse_internal_or!{$input, |i| __parse_internal!{@EXPR_SKIP(i;) $($lhs)* $t1 $t2 $t3 $t4 $t5 $t6 $t7}, |i| __parse_internal!{@EXPR_ALT(i;) $($tail)*}} };
+    ( @EXPR_ALT($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt $($tail:tt)* ) => { __parse_internal!{@EXPR_ALT($input; $($lhs)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8) $($tail)*} };
 
     // ExprSkip ::= Term
     ( @EXPR_SKIP($input:expr; $($lhs:tt)*) )                     => { __parse_internal!{@TERM($input) $($lhs)*} };
     //            | Term <* ExprSkip
     ( @EXPR_SKIP($input:expr; $($lhs:tt)*) <* $($tail:tt)* )     => { __parse_internal!{@TERM($input) $($lhs)*}.bind(|i, l| __parse_internal!{@EXPR_SKIP(i;) $($tail)*}.map(|_| l)) };
     // recurse until <* or end
-    ( @EXPR_SKIP($input:expr; $($lhs:tt)*) $t1:tt $($tail:tt)* ) => { __parse_internal!{@EXPR_SKIP($input; $($lhs)* $t1) $($tail)*} };
+    // unrolled:
+    // ( @EXPR_SKIP($input:expr; $($lhs:tt)*) $t1:tt $($tail:tt)* ) => { __parse_internal!{@EXPR_SKIP($input; $($lhs)* $t1) $($tail)*} };
+    ( @EXPR_SKIP($input:expr; $($lhs:tt)*) $t1:tt )                                          => { __parse_internal!{@TERM($input) $($lhs)* $t1} };
+    ( @EXPR_SKIP($input:expr; $($lhs:tt)*) $t1:tt <* $($tail:tt)* )                          => { __parse_internal!{@TERM($input) $($lhs)* $t1}.bind(|i, l| __parse_internal!{@EXPR_SKIP(i;) $($tail)*}.map(|_| l)) };
+    ( @EXPR_SKIP($input:expr; $($lhs:tt)*) $t1:tt $t2:tt )                                   => { __parse_internal!{@TERM($input) $($lhs)* $t1 $t2} };
+    ( @EXPR_SKIP($input:expr; $($lhs:tt)*) $t1:tt $t2:tt <* $($tail:tt)* )                   => { __parse_internal!{@TERM($input) $($lhs)* $t1 $t2}.bind(|i, l| __parse_internal!{@EXPR_SKIP(i;) $($tail)*}.map(|_| l)) };
+    ( @EXPR_SKIP($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt )                            => { __parse_internal!{@TERM($input) $($lhs)* $t1 $t2 $t3} };
+    ( @EXPR_SKIP($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt <* $($tail:tt)* )            => { __parse_internal!{@TERM($input) $($lhs)* $t1 $t2 $t3}.bind(|i, l| __parse_internal!{@EXPR_SKIP(i;) $($tail)*}.map(|_| l)) };
+    ( @EXPR_SKIP($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt )                     => { __parse_internal!{@TERM($input) $($lhs)* $t1 $t2 $t3 $t4} };
+    ( @EXPR_SKIP($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt <* $($tail:tt)* )     => { __parse_internal!{@TERM($input) $($lhs)* $t1 $t2 $t3 $t4}.bind(|i, l| __parse_internal!{@EXPR_SKIP(i;) $($tail)*}.map(|_| l)) };
+    ( @EXPR_SKIP($input:expr; $($lhs:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $($tail:tt)* ) => { __parse_internal!{@EXPR_SKIP($input; $($lhs)* $t1 $t2 $t3 $t4 $t5) $($tail)*} };
 
     // STATEMENT eats and groups a full parse! expression until the next ;
     ( @STATEMENT($args:tt $($data:tt)*) )                        => { __parse_internal!{@BIND($args $($data)*)} };
@@ -342,21 +384,27 @@ macro_rules! __parse_internal {
     // Technically could just use a single pattern for this recursion:
     // ( @STATEMENT($args:tt $($data:tt)*) $t:tt $($tail:tt)* ) => { __parse_internal!{@STATEMENT($args $($data)* $t) $($tail)*} };
     // But to avoid the recursion limit somewhat we have explicit cases for up to 7 tokens before ; or end:
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt )                                                               => { __parse_internal!{@BIND($args $($data)* $t1)} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt ; $($tail:tt)* )                                                => { __parse_internal!{@BIND($args $($data)* $t1) $($tail)*} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt )                                                        => { __parse_internal!{@BIND($args $($data)* $t1 $t2)} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt ; $($tail:tt)* )                                         => { __parse_internal!{@BIND($args $($data)* $t1 $t2) $($tail)*} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt )                                                 => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3)} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt ; $($tail:tt)* )                                  => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3) $($tail)*} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt )                                          => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4)} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt ; $($tail:tt)* )                           => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4) $($tail)*} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt )                                   => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5)} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt ; $($tail:tt)* )                    => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5) $($tail)*} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt )                            => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6)} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt ; $($tail:tt)* )             => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6) $($tail)*} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt )                     => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7)} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt ; $($tail:tt)* )      => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7) $($tail)*} };
-    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt $($tail:tt)* ) => { __parse_internal!{@STATEMENT($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt )                                                                                      => { __parse_internal!{@BIND($args $($data)* $t1)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt ; $($tail:tt)* )                                                                       => { __parse_internal!{@BIND($args $($data)* $t1) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt )                                                                               => { __parse_internal!{@BIND($args $($data)* $t1 $t2)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt ; $($tail:tt)* )                                                                => { __parse_internal!{@BIND($args $($data)* $t1 $t2) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt )                                                                        => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt ; $($tail:tt)* )                                                         => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt )                                                                 => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt ; $($tail:tt)* )                                                  => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt )                                                          => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt ; $($tail:tt)* )                                           => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt )                                                   => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt ; $($tail:tt)* )                                    => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt )                                            => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt ; $($tail:tt)* )                             => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt )                                     => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt ; $($tail:tt)* )                      => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt $t9:tt )                              => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8 $t9)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt $t9:tt ; $($tail:tt)* )               => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8 $t9) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt $t9:tt $t10:tt )                      => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8 $t9 $t10)} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt $t9:tt $t10:tt ; $($tail:tt)* )       => { __parse_internal!{@BIND($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8 $t9 $t10) $($tail)*} };
+    ( @STATEMENT($args:tt $($data:tt)*) $t1:tt $t2:tt $t3:tt $t4:tt $t5:tt $t6:tt $t7:tt $t8:tt $t9:tt $t10:tt $t11:tt $($tail:tt)* ) => { __parse_internal!{@STATEMENT($args $($data)* $t1 $t2 $t3 $t4 $t5 $t6 $t7 $t8 $t9 $t10 $t11) $($tail)*} };
 
     // Public rules:
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1397,32 +1397,19 @@ mod test {
         assert_eq!(r, Data::Value(333, 21));
     }
 
-// Block     ::= Statement* Expr
-// Statement ::= Bind ';'
-//             | Expr ';'
-// Bind      ::= 'let' Var '=' Expr
-// Var       ::= $pat
-//             | $ident ':' $ty
-//
-// /* Expr is split this way to allow for operator precedence */
-// Expr      ::= ExprAlt
-//             | ExprAlt   ">>" Expr
-// ExprAlt   ::= ExprSkip
-//             | ExprSkip "<|>" ExprAlt
-// ExprSkip  ::= Term
-//             | Term     "<*" ExprSkip
-//
-// Term      ::= Ret
-//             | Err
-//             | '(' Expr ')'
-//             | Inline
-//             | Named
-//
-// Ret       ::= "ret" Typed
-//             | "ret" $expr
-// Err       ::= "err" Typed
-//             | "err" $expr
-// Typed     ::= '@' $ty ',' $ty ':' $expr
-// Inline    ::= $ident "->" $expr
-// Named     ::= $ident '(' ($expr ',')* (',')* ')'
+    // Test to make sure we do not hit the default macro iteration limit (64)
+    #[test]
+    fn max_alt() {
+        fn a(i: Input) -> Data<u32, ()> {
+            assert_eq!(i, Input(123));
+
+            Data::Value(321, 2)
+        }
+
+        let i = Input(123);
+
+        let r = parse!{i; a() <|> a() <|> a() <|> a() <|> a() <|> a() <|> a() <|> a() <|> a()};
+
+        assert_eq!(r, Data::Value(321, 2));
+    }
 }

--- a/tests/compile-fail/macros_tailing_bind1.rs
+++ b/tests/compile-fail/macros_tailing_bind1.rs
@@ -1,4 +1,4 @@
-// error-pattern:error: unexpected token: `@`
+// error-pattern:error: expected ident, found x
 
 #[macro_use]
 extern crate chomp;

--- a/tests/compile-fail/macros_tailing_bind2.rs
+++ b/tests/compile-fail/macros_tailing_bind2.rs
@@ -1,4 +1,4 @@
-// error-pattern:error: unexpected token: `@`
+// error-pattern:error: expected ident, found x
 
 #[macro_use]
 extern crate chomp;

--- a/tests/compile-fail/macros_tailing_bind3.rs
+++ b/tests/compile-fail/macros_tailing_bind3.rs
@@ -1,4 +1,4 @@
-// error-pattern:error: unexpected token: `@`
+// error-pattern:error: expected ident, found x
 
 #[macro_use]
 extern crate chomp;

--- a/tests/compile-fail/macros_tailing_bind4.rs
+++ b/tests/compile-fail/macros_tailing_bind4.rs
@@ -1,4 +1,4 @@
-// error-pattern:error: unexpected token: `@`
+// error-pattern:error: expected ident, found x
 
 #[macro_use]
 extern crate chomp;


### PR DESCRIPTION
Generalizes parts of the syntax (eg. enables `ret` and `err` to be used in `let`-statements) and allows for operators in the expressions for `let`-statements and actions.

### New grammar

```ebnf
Block     ::= Statement* Expr
Statement ::= Bind ';'
            | Expr ';'
Bind      ::= 'let' Var '=' Expr
Var       ::= $pat
            | $ident ':' $ty

Expr      ::= ExprAlt
            | ExprAlt ">>" Expr
ExprAlt   ::= ExprSkip
            | ExprSkip "<|>" ExprAlt
ExprSkip  ::= Term
            | Term "<*" ExprSkip

/* Needs to be followed by , or ; because of trailing $expr on Ret, Err and Inline.
   Alternatively be wrapped in parentheses */
Term      ::= Ret
            | Err
            | Inline
            | Named
            | '(' Expr ')'

Ret       ::= "ret" Typed
            | "ret" $expr
Err       ::= "err" Typed
            | "err" $expr
Typed     ::= '@' $ty ',' $ty ':' $expr
Inline    ::= $ident "->" $expr
Named     ::= $ident '(' ($expr ',')* (',')* ')'
```

**NOTE:** This change is backwards incompatible as it does not allow for tailing semicolons in `parse!` macros.

### Operators

* `<|>`: Same as Haskell's `Alternative` typeclass, it attempts to parse the left hand side and if it fails it will retry with the right hand side
* `<*`: Same as Haskell's `Applicative` typeclass, it parses the left hand side, then the right hand side and throws away any result from the right hand side while keeping the result of the left hand side
* `>>`: Same as Haskell's `Monad` (and Chomp's `then`)

These operators have the same operator precedence as Haskell but are right-associative (at the moment of writing). The right-associativity and operator precedence follows from the fact that rust-macros parse from left to right and just using plain tt-munching to chain them together will keep that order.

### Examples

I am not sure if I want to make the operators left-associative, though there are cases both for and against:

```rust
parse!{i; decimal() <* token(b';') >> token(b' ')}
// will be interpreted as
decimal(i).skip(|i token(i, b';')).then(|i| token(i, b' '))
// which is the same as in haskell
// decimal <* token ';' >> token ' '

parse!{i; decimal() <* token(b';') <|> any()}
// will be interpreted as
or(i, |i| decimal(i).skip(|i| token(b';')), any)
// same in Haskell:
// decimal <* token ';' <|> any
```

Needs a few more tests before it is good to merge.