### PR TITLE
Removed unused lifetime from err::expected(_)

### DIFF
--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -473,7 +473,7 @@ mod err {
     }
 
     #[inline(always)]
-    pub fn expected<'a, I>(i: I) -> Error<I> {
+    pub fn expected<I>(i: I) -> Error<I> {
         Error::Expected(i)
     }
 


### PR DESCRIPTION
This is the only clippy warning I could find, which means clippy – and I – deem this good code :smile: