### PR TITLE
Simplified error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ after_success:
 env:
   matrix:
     - FEATURES="--features noop_error"
+    - FEATURES="--features backtrace"
+    - FEATURES="--features \"noop_error backtrace\""
     - FEATURES=""
   global:
     - secure: gsvH3282enp+tO7Hjd0BEUnv9+jX0uQ/E9+B07ZPcbjYvoSA68Hk2UfZb1IYMWWXO1mWR8zF1Q/AnZR26fYEtlGaF8vTRqoYQHCc5pYUxNaSJPf1C2fvGpiRW63h9lC9sAwia7r2oS+aBeXHdrxvPtScMescf+fzjdeTYy4sHAg9ahrMIDlXB2cFXBixyqbjKwPB3wT0VqjOc8avzhAKehxXU8/h51P2FjRXLv/aEs/cMV7vpGGAZG4uA9cgrql7zayWMdiUNFGzR0Di7r3tDK3TPsla1c1W5+YYrbWkXT/cX5AvpDa9IH+jookPITzNlN7v6ZAQiwBzE7U2qzbZu34QAk34lfEwlcF/wVfuiKfUwR/U+B8Lb5tFPBF1lWn/NOw+uec4d/0XO2K6sfVxXn0nMrfeA/L8Q3pJ+3Fmts+gP4oumrjZ9L+zoYE+Lpn22T2W81BOPuW2c1JvbB5ZDds4ztHc2BL4aiYSO9DzMYTCz4sT/UbDbgVWkhwwfeKarCAvTmfTfpgIsNdnMdkiMX4gLIzm1W0xwtTc8Tl7GgCQjO8zxcgZT67bi507Huf9zQ4AwaBN4P9jCGSsa+bleIcUeR5NkX2KJlT5WNqUIyCHqHwG18Ddm8jmSMut4AVsyXkdAONq4Xfa07cZUBoKtAahrgl8UqXclCjtw31acGk=

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,5 @@ after_success:
 env:
   matrix:
     - FEATURES=""
-    - FEATURES="--no-default-features"
   global:
     - secure: gsvH3282enp+tO7Hjd0BEUnv9+jX0uQ/E9+B07ZPcbjYvoSA68Hk2UfZb1IYMWWXO1mWR8zF1Q/AnZR26fYEtlGaF8vTRqoYQHCc5pYUxNaSJPf1C2fvGpiRW63h9lC9sAwia7r2oS+aBeXHdrxvPtScMescf+fzjdeTYy4sHAg9ahrMIDlXB2cFXBixyqbjKwPB3wT0VqjOc8avzhAKehxXU8/h51P2FjRXLv/aEs/cMV7vpGGAZG4uA9cgrql7zayWMdiUNFGzR0Di7r3tDK3TPsla1c1W5+YYrbWkXT/cX5AvpDa9IH+jookPITzNlN7v6ZAQiwBzE7U2qzbZu34QAk34lfEwlcF/wVfuiKfUwR/U+B8Lb5tFPBF1lWn/NOw+uec4d/0XO2K6sfVxXn0nMrfeA/L8Q3pJ+3Fmts+gP4oumrjZ9L+zoYE+Lpn22T2W81BOPuW2c1JvbB5ZDds4ztHc2BL4aiYSO9DzMYTCz4sT/UbDbgVWkhwwfeKarCAvTmfTfpgIsNdnMdkiMX4gLIzm1W0xwtTc8Tl7GgCQjO8zxcgZT67bi507Huf9zQ4AwaBN4P9jCGSsa+bleIcUeR5NkX2KJlT5WNqUIyCHqHwG18Ddm8jmSMut4AVsyXkdAONq4Xfa07cZUBoKtAahrgl8UqXclCjtw31acGk=

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ env:
   matrix:
     - FEATURES="--features noop_error"
     - FEATURES="--features backtrace"
-    - FEATURES="--features \"noop_error backtrace\""
+    # Travis seems to have issues with quotation in env-vars, use a merged feature
+    - FEATURES="--features noop_error_and_backtrace"
     - FEATURES=""
   global:
     - secure: gsvH3282enp+tO7Hjd0BEUnv9+jX0uQ/E9+B07ZPcbjYvoSA68Hk2UfZb1IYMWWXO1mWR8zF1Q/AnZR26fYEtlGaF8vTRqoYQHCc5pYUxNaSJPf1C2fvGpiRW63h9lC9sAwia7r2oS+aBeXHdrxvPtScMescf+fzjdeTYy4sHAg9ahrMIDlXB2cFXBixyqbjKwPB3wT0VqjOc8avzhAKehxXU8/h51P2FjRXLv/aEs/cMV7vpGGAZG4uA9cgrql7zayWMdiUNFGzR0Di7r3tDK3TPsla1c1W5+YYrbWkXT/cX5AvpDa9IH+jookPITzNlN7v6ZAQiwBzE7U2qzbZu34QAk34lfEwlcF/wVfuiKfUwR/U+B8Lb5tFPBF1lWn/NOw+uec4d/0XO2K6sfVxXn0nMrfeA/L8Q3pJ+3Fmts+gP4oumrjZ9L+zoYE+Lpn22T2W81BOPuW2c1JvbB5ZDds4ztHc2BL4aiYSO9DzMYTCz4sT/UbDbgVWkhwwfeKarCAvTmfTfpgIsNdnMdkiMX4gLIzm1W0xwtTc8Tl7GgCQjO8zxcgZT67bi507Huf9zQ4AwaBN4P9jCGSsa+bleIcUeR5NkX2KJlT5WNqUIyCHqHwG18Ddm8jmSMut4AVsyXkdAONq4Xfa07cZUBoKtAahrgl8UqXclCjtw31acGk=

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ after_success:
 
 env:
   matrix:
+    - FEATURES="--features noop_error"
     - FEATURES=""
   global:
     - secure: gsvH3282enp+tO7Hjd0BEUnv9+jX0uQ/E9+B07ZPcbjYvoSA68Hk2UfZb1IYMWWXO1mWR8zF1Q/AnZR26fYEtlGaF8vTRqoYQHCc5pYUxNaSJPf1C2fvGpiRW63h9lC9sAwia7r2oS+aBeXHdrxvPtScMescf+fzjdeTYy4sHAg9ahrMIDlXB2cFXBixyqbjKwPB3wT0VqjOc8avzhAKehxXU8/h51P2FjRXLv/aEs/cMV7vpGGAZG4uA9cgrql7zayWMdiUNFGzR0Di7r3tDK3TPsla1c1W5+YYrbWkXT/cX5AvpDa9IH+jookPITzNlN7v6ZAQiwBzE7U2qzbZu34QAk34lfEwlcF/wVfuiKfUwR/U+B8Lb5tFPBF1lWn/NOw+uec4d/0XO2K6sfVxXn0nMrfeA/L8Q3pJ+3Fmts+gP4oumrjZ9L+zoYE+Lpn22T2W81BOPuW2c1JvbB5ZDds4ztHc2BL4aiYSO9DzMYTCz4sT/UbDbgVWkhwwfeKarCAvTmfTfpgIsNdnMdkiMX4gLIzm1W0xwtTc8Tl7GgCQjO8zxcgZT67bi507Huf9zQ4AwaBN4P9jCGSsa+bleIcUeR5NkX2KJlT5WNqUIyCHqHwG18Ddm8jmSMut4AVsyXkdAONq4Xfa07cZUBoKtAahrgl8UqXclCjtw31acGk=

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,7 @@ compiletest_rs = { version = "0.1.1", optional = true }
 unstable      = ["compiletest_rs"]
 noop_error    = []
 backtrace     = ["debugtrace/backtrace"]
+
+# Feature for travis, so that both noop_error and backtrace can be enabled simultaneously
+# without causing parse-errors in the argument parser in travis-cargo.
+noop_error_and_backtrace = ["noop_error", "backtrace"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,9 @@ include = [
 ]
 
 [dependencies]
-bitflags  = "0.5.0"
-conv      = { version = "0.3", default-features = false }
-backtrace = { version = "0.1.8", optional = true }
+bitflags   = "0.5.0"
+conv       = { version = "0.3", default-features = false }
+debugtrace = { version = "0.1.0" }
 
 # Technically a dev-dependency, but dev-dependencies are not allowed to be optional,
 # compiletest_rs fails to compile on stable and beta
@@ -34,3 +34,4 @@ compiletest_rs = { version = "0.1.1", optional = true }
 # Feature for running extra (compiletime fail) tests on nightly
 unstable      = ["compiletest_rs"]
 noop_error    = []
+backtrace     = ["debugtrace/backtrace"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,5 @@ conv     = { version = "0.3", default-features = false }
 compiletest_rs = { version = "0.1.1", optional = true }
 
 [features]
-default       = ["verbose_error"]
-verbose_error = []
 # Feature for running extra (compiletime fail) tests on nightly
 unstable      = ["compiletest_rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ compiletest_rs = { version = "0.1.1", optional = true }
 [features]
 # Feature for running extra (compiletime fail) tests on nightly
 unstable      = ["compiletest_rs"]
+noop_error    = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,9 @@ include = [
 ]
 
 [dependencies]
-bitflags = "0.5.0"
-conv     = { version = "0.3", default-features = false }
+bitflags  = "0.5.0"
+conv      = { version = "0.3", default-features = false }
+backtrace = { version = "0.1.8", optional = true }
 
 # Technically a dev-dependency, but dev-dependencies are not allowed to be optional,
 # compiletest_rs fails to compile on stable and beta

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -21,7 +21,7 @@ use primitives::{IntoInner, InputBuffer, InputClone};
 ///     count(i, 2, |i| token(i, b'a'))
 /// }
 ///
-/// assert_eq!(parse_only(parse, b"a  "), Err(ParseError::Error(b"  ", Error::Expected(b'a'))));
+/// assert_eq!(parse_only(parse, b"a  "), Err(ParseError::Error(b"  ", Error::expected(b'a'))));
 /// assert_eq!(parse_only(parse, b"aa "), Ok(vec![b'a', b'a']));
 ///
 /// let with_remainder = |i| parse(i).bind(|i, d| take_remainder(i).map(|r| (r, d)));
@@ -84,7 +84,7 @@ pub fn option<'a, I, T, E, F>(i: Input<'a, I>, f: F, default: T) -> ParseResult<
 ///
 /// assert_eq!(parse_only(&p, b"abc"), Ok(b'a'));
 /// assert_eq!(parse_only(&p, b"bbc"), Ok(b'b'));
-/// assert_eq!(parse_only(&p, b"cbc"), Err(ParseError::Error(b"cbc", Error::Expected(b'b'))));
+/// assert_eq!(parse_only(&p, b"cbc"), Err(ParseError::Error(b"cbc", Error::expected(b'b'))));
 /// ```
 #[inline]
 pub fn or<'a, I, T, E, F, G>(i: Input<'a, I>, f: F, g: G) -> ParseResult<'a, I, T, E>
@@ -144,7 +144,7 @@ pub fn many<'a, I, T, E, F, U>(i: Input<'a, I>, f: F) -> ParseResult<'a, I, T, E
 ///             .bind(|i, c| token(i, b',')
 ///                          .map(|_| c)));
 ///
-/// assert_eq!(parse_only(&p, b"a "), Err(ParseError::Error(b" ", Error::Expected(b','))));
+/// assert_eq!(parse_only(&p, b"a "), Err(ParseError::Error(b" ", Error::expected(b','))));
 /// assert_eq!(parse_only(&p, b"a, "), Ok(vec![&b"a"[..]]));
 /// ```
 #[inline]
@@ -278,7 +278,7 @@ pub fn skip_many<'a, I, T, E, F>(i: Input<'a, I>, f: F) -> ParseResult<'a, I, ()
 /// assert_eq!(parse_only(&p, b"aaaabc"), Ok(b'b'));
 /// assert_eq!(parse_only(&p, b"abc"), Ok(b'b'));
 ///
-/// assert_eq!(parse_only(&p, b"bc"), Err(ParseError::Error(b"bc", Error::Expected(b'a'))));
+/// assert_eq!(parse_only(&p, b"bc"), Err(ParseError::Error(b"bc", Error::expected(b'a'))));
 /// ```
 #[inline]
 pub fn skip_many1<'a, I, T, E, F>(i: Input<'a, I>, f: F) -> ParseResult<'a, I, (), E>

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -14,22 +14,20 @@ use primitives::{IntoInner, InputBuffer, InputClone};
 
 /// Applies the parser ``p`` exactly ``num`` times collecting all items into `T: FromIterator`.
 ///
-#[cfg_attr(feature = "verbose_error", doc = "
-```
- use chomp::{U8Result, ParseError, Error, Input, parse_only, count, token, take_remainder};
-
- fn parse(i: Input<u8>) -> U8Result<Vec<u8>> {
-     count(i, 2, |i| token(i, b'a'))
- }
-
- assert_eq!(parse_only(parse, b\"a  \"), Err(ParseError::Error(b\"  \", Error::Expected(b'a'))));
- assert_eq!(parse_only(parse, b\"aa \"), Ok(vec![b'a', b'a']));
-
- let with_remainder = |i| parse(i).bind(|i, d| take_remainder(i).map(|r| (r, d)));
-
- assert_eq!(parse_only(with_remainder, b\"aaa\"), Ok((&b\"a\"[..], vec![b'a', b'a'])));
-```
-")]
+/// ```
+/// use chomp::{U8Result, ParseError, Error, Input, parse_only, count, token, take_remainder};
+///
+/// fn parse(i: Input<u8>) -> U8Result<Vec<u8>> {
+///     count(i, 2, |i| token(i, b'a'))
+/// }
+///
+/// assert_eq!(parse_only(parse, b"a  "), Err(ParseError::Error(b"  ", Error::Expected(b'a'))));
+/// assert_eq!(parse_only(parse, b"aa "), Ok(vec![b'a', b'a']));
+///
+/// let with_remainder = |i| parse(i).bind(|i, d| take_remainder(i).map(|r| (r, d)));
+///
+/// assert_eq!(parse_only(with_remainder, b"aaa"), Ok((&b"a"[..], vec![b'a', b'a'])));
+/// ```
 #[inline]
 pub fn count<'a, I, T, E, F, U>(i: Input<'a, I>, num: usize, p: F) -> ParseResult<'a, I, T, E>
   where I: Copy,
@@ -77,19 +75,17 @@ pub fn option<'a, I, T, E, F>(i: Input<'a, I>, f: F, default: T) -> ParseResult<
 /// If multiple `or` combinators are used in the same expression, consider using the `parse!` macro
 /// and its alternation operator (`<|>`).
 ///
-#[cfg_attr(feature = "verbose_error", doc = "
-```
- use chomp::{ParseError, Error, parse_only, or, token};
-
- let p = |i| or(i,
-             |i| token(i, b'a'),
-             |i| token(i, b'b'));
-
- assert_eq!(parse_only(&p, b\"abc\"), Ok(b'a'));
- assert_eq!(parse_only(&p, b\"bbc\"), Ok(b'b'));
- assert_eq!(parse_only(&p, b\"cbc\"), Err(ParseError::Error(b\"cbc\", Error::Expected(b'b'))));
-```
-")]
+/// ```
+/// use chomp::{ParseError, Error, parse_only, or, token};
+///
+/// let p = |i| or(i,
+///             |i| token(i, b'a'),
+///             |i| token(i, b'b'));
+///
+/// assert_eq!(parse_only(&p, b"abc"), Ok(b'a'));
+/// assert_eq!(parse_only(&p, b"bbc"), Ok(b'b'));
+/// assert_eq!(parse_only(&p, b"cbc"), Err(ParseError::Error(b"cbc", Error::Expected(b'b'))));
+/// ```
 #[inline]
 pub fn or<'a, I, T, E, F, G>(i: Input<'a, I>, f: F, g: G) -> ParseResult<'a, I, T, E>
   where F: FnOnce(Input<'a, I>) -> ParseResult<'a, I, T, E>,
@@ -141,18 +137,16 @@ pub fn many<'a, I, T, E, F, U>(i: Input<'a, I>, f: F) -> ParseResult<'a, I, T, E
 ///
 /// Note: Allocates data.
 ///
-#[cfg_attr(feature = "verbose_error", doc = "
-```
- use chomp::{ParseError, Error, parse_only, token, many1, take_while1};
-
- let p = |i| many1(i, |i| take_while1(i, |c| c != b',' && c != b' ')
-             .bind(|i, c| token(i, b',')
-                          .map(|_| c)));
-
- assert_eq!(parse_only(&p, b\"a \"), Err(ParseError::Error(b\" \", Error::Expected(b','))));
- assert_eq!(parse_only(&p, b\"a, \"), Ok(vec![&b\"a\"[..]]));
-```
-")]
+/// ```
+/// use chomp::{ParseError, Error, parse_only, token, many1, take_while1};
+///
+/// let p = |i| many1(i, |i| take_while1(i, |c| c != b',' && c != b' ')
+///             .bind(|i, c| token(i, b',')
+///                          .map(|_| c)));
+///
+/// assert_eq!(parse_only(&p, b"a "), Err(ParseError::Error(b" ", Error::Expected(b','))));
+/// assert_eq!(parse_only(&p, b"a, "), Ok(vec![&b"a"[..]]));
+/// ```
 #[inline]
 pub fn many1<'a, I, T, E, F, U>(i: Input<'a, I>, f: F) -> ParseResult<'a, I, T, E>
   where I: Copy,
@@ -276,18 +270,16 @@ pub fn skip_many<'a, I, T, E, F>(i: Input<'a, I>, f: F) -> ParseResult<'a, I, ()
 /// This is more efficient compared to using ``many1`` and then just discarding the result as
 /// ``many1`` allocates a separate data structure to contain the data before proceeding.
 ///
-#[cfg_attr(feature = "verbose_error", doc = "
-```
- use chomp::{ParseError, Error, parse_only, skip_many1, token};
-
- let p = |i| skip_many1(i, |i| token(i, b'a')).bind(|i, _| token(i, b'b'));
-
- assert_eq!(parse_only(&p, b\"aaaabc\"), Ok(b'b'));
- assert_eq!(parse_only(&p, b\"abc\"), Ok(b'b'));
-
- assert_eq!(parse_only(&p, b\"bc\"), Err(ParseError::Error(b\"bc\", Error::Expected(b'a'))));
-```
-")]
+/// ```
+/// use chomp::{ParseError, Error, parse_only, skip_many1, token};
+///
+/// let p = |i| skip_many1(i, |i| token(i, b'a')).bind(|i, _| token(i, b'b'));
+///
+/// assert_eq!(parse_only(&p, b"aaaabc"), Ok(b'b'));
+/// assert_eq!(parse_only(&p, b"abc"), Ok(b'b'));
+///
+/// assert_eq!(parse_only(&p, b"bc"), Err(ParseError::Error(b"bc", Error::Expected(b'a'))));
+/// ```
 #[inline]
 pub fn skip_many1<'a, I, T, E, F>(i: Input<'a, I>, f: F) -> ParseResult<'a, I, (), E>
   where T: 'a, F: FnMut(Input<'a, I>) -> ParseResult<'a, I, T, E> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,10 +178,36 @@
 //!   type of the entire parser, should it succeed.
 //!
 //! The entire grammar for the macro is listed elsewhere in this documentation.
+//!
+//! # Features
+//!
+//! * `backtrace`:
+#![cfg_attr(feature="backtrace", doc = " enabled.")]
+#![cfg_attr(not(feature="backtrace"), doc = " disabled (default).")]
+//!
+//!    This feature enables for backtraces of parse-errors, either by calling `Error::trace` or by
+//!    printing it using `fmt::Debug`.
+//!
+//!    This incurs a performance-hit every time a `chomp::parsers` parser fails since a backtrace
+//!    must be collected.
+//!
+//!    Incompatible with `noop_error`.
+//!
+//! * `noop_error`:
+#![cfg_attr(not(feature="noop_error"), doc = " disabled (default).")]
+#![cfg_attr(feature="noop_error", doc = " enabled.")]
+//!
+//!    The built-in `chomp::parsers::Error` type is zero-sized and carry no error-information. This
+//!    increases performance somewhat.
+//!
+//!    Incompatible with `backtrace`.
 
 #[macro_use]
 extern crate bitflags;
 extern crate conv;
+
+#[cfg(feature="backtrace")]
+extern crate backtrace;
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,13 +185,14 @@
 #![cfg_attr(feature="backtrace", doc = " enabled.")]
 #![cfg_attr(not(feature="backtrace"), doc = " disabled (default).")]
 //!
-//!    This feature enables for backtraces of parse-errors, either by calling `Error::trace` or by
+//!    This feature enables backtraces for parse-errors, either by calling `Error::trace` or by
 //!    printing it using `fmt::Debug`.
 //!
 //!    This incurs a performance-hit every time a `chomp::parsers` parser fails since a backtrace
 //!    must be collected.
 //!
-//!    Incompatible with `noop_error`.
+//!    In the `dev` and `test` profiles backtraces will always be enabled. This does not incur any
+//!    cost when built using the `release` profile unless the `backtrace` feature is enabled.
 //!
 //! * `noop_error`:
 #![cfg_attr(not(feature="noop_error"), doc = " disabled (default).")]
@@ -199,15 +200,11 @@
 //!
 //!    The built-in `chomp::parsers::Error` type is zero-sized and carry no error-information. This
 //!    increases performance somewhat.
-//!
-//!    Incompatible with `backtrace`.
 
 #[macro_use]
 extern crate bitflags;
 extern crate conv;
-
-#[cfg(feature="backtrace")]
-extern crate backtrace;
+extern crate debugtrace;
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@
 //! ```
 //! # #[macro_use] extern crate chomp;
 //! # fn main() {
-//! # use chomp::{Input, satisfy, parse_only};
+//! # use chomp::{satisfy, parse_only};
 //! # let r = parse_only(parser!{
 //! satisfy(|c| {
 //!     match c {
@@ -144,7 +144,7 @@
 //!
 //! ```
 //! # #[macro_use] extern crate chomp;
-//! # use chomp::{Input, parse_only, satisfy, string, token, U8Result};
+//! # use chomp::{Input, parse_only, satisfy, string, U8Result};
 //! fn f(i: Input<u8>) -> U8Result<(u8, u8, u8)> {
 //!     parse!{i;
 //!         let a = digit();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -186,8 +186,7 @@
 /// ```
 /// # #[macro_use] extern crate chomp;
 /// # fn main() {
-/// # use chomp::ascii::decimal;
-/// # use chomp::{parse_only, Input, token, U8Result};
+/// # use chomp::{parse_only, Input, U8Result};
 /// # fn my_parser(i: Input<u8>) -> U8Result<&'static str> {
 /// fn do_it<'i, 'a>(i: Input<'i, u8>, s: &'a str) -> U8Result<'i, &'a str> { i.ret(s) }
 ///
@@ -326,7 +325,7 @@
 /// ```
 /// # #[macro_use] extern crate chomp;
 /// # fn main() {
-/// # use chomp::{parse_only, token};
+/// # use chomp::{parse_only};
 /// let p = parser!{ (i -> i.err("foo")) <|> (i -> i.ret("bar")) };
 ///
 /// assert_eq!(parse_only(p, b"a;"), Ok("bar"));

--- a/src/parse_result.rs
+++ b/src/parse_result.rs
@@ -354,7 +354,7 @@ impl<'a, I, T: fmt::Debug, E> ParseResult<'a, I, T, E> {
     ///
     /// let r = token(Input::new(b"a"), b'b');
     ///
-    /// assert_eq!(r.unwrap_err(), Error::Expected(98));
+    /// assert_eq!(r.unwrap_err(), Error::expected(98));
     /// ```
     ///
     /// ```{.should_panic}
@@ -363,7 +363,7 @@ impl<'a, I, T: fmt::Debug, E> ParseResult<'a, I, T, E> {
     /// let r = token(Input::new(b"a"), b'a');
     ///
     /// // Panics with "called `ParseResult::unwrap_err` on a success state: 97"
-    /// assert_eq!(r.unwrap_err(), Error::Expected(98));
+    /// assert_eq!(r.unwrap_err(), Error::expected(98));
     /// ```
     #[inline]
     pub fn unwrap_err(self) -> E {

--- a/src/parse_result.rs
+++ b/src/parse_result.rs
@@ -347,27 +347,24 @@ impl<'a, I, T: fmt::Debug, E> ParseResult<'a, I, T, E> {
     /// Panics if the parse result is in a success-state or if the parsing is incomplete. Will
     /// provide a panic message based on the value of the success or incomplete state.
     ///
-    #[cfg_attr(feature = "verbose_error", doc = "
-
- # Examples
-
- ```
- use chomp::{Error, Input, token};
-
- let r = token(Input::new(b\"a\"), b'b');
-
- assert_eq!(r.unwrap_err(), Error::Expected(98));
- ```
-
- ```{.should_panic}
- use chomp::{Error, Input, token};
-
- let r = token(Input::new(b\"a\"), b'a');
-
- // Panics with \"called `ParseResult::unwrap_err` on a success state: 97\"
- assert_eq!(r.unwrap_err(), Error::Expected(98));
- ```
-    ")]
+    /// # Examples
+    ///
+    /// ```
+    /// use chomp::{Error, Input, token};
+    ///
+    /// let r = token(Input::new(b"a"), b'b');
+    ///
+    /// assert_eq!(r.unwrap_err(), Error::Expected(98));
+    /// ```
+    ///
+    /// ```{.should_panic}
+    /// use chomp::{Error, Input, token};
+    ///
+    /// let r = token(Input::new(b"a"), b'a');
+    ///
+    /// // Panics with "called `ParseResult::unwrap_err` on a success state: 97"
+    /// assert_eq!(r.unwrap_err(), Error::Expected(98));
+    /// ```
     #[inline]
     pub fn unwrap_err(self) -> E {
         match self.0 {

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -719,6 +719,6 @@ mod test {
         let trace = e.trace();
         let this  = &trace[0];
 
-        assert!(this.name.as_ref().map(|n| n.starts_with("parsers::test::backtrace_test")).unwrap_or(false), "Expected trace to start with \"parsers::test::backtrace_test\", got: {:?}", this.name.as_ref());
+        assert!(this.name.as_ref().map(|n| n.contains("parsers::test::backtrace_test")).unwrap_or(false), "Expected trace to contain \"parsers::test::backtrace_test\", got: {:?}", this.name.as_ref());
     }
 }

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -402,11 +402,11 @@ pub fn eof<I>(i: Input<I>) -> SimpleResult<I, ()> {
     }
 }
 
-/// Common error for the basic Chomp parsers, verbose version.
+/// Common error for the basic Chomp parsers.
 ///
-/// This is a verbose version of the common error for the basic Chomp parsers. It will contain
-/// information about what a parser expected or if it encountered something unexpected (in the
-/// case of user supplied predicates, eg. `satisfy`).
+/// This is the common error for the basic Chomp parsers. It will contain information about what a
+/// parser expected or if it encountered something unexpected (in the case of user supplied
+/// predicates, eg. `satisfy`).
 ///
 /// This is coupled with the state found in the error state of the `ParseResult` type.
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -574,4 +574,21 @@ mod test {
         assert_eq!(m2, 0);
         assert_eq!(n2, 0);
     }
+
+    #[test]
+    fn string_test() {
+        assert_eq!(string(new(DEFAULT, b"abc"), b"a").into_inner(), State::Data(new(DEFAULT, b"bc"), &b"a"[..]));
+        assert_eq!(string(new(DEFAULT, b"abc"), b"ab").into_inner(), State::Data(new(DEFAULT, b"c"), &b"ab"[..]));
+        assert_eq!(string(new(DEFAULT, b"abc"), b"abc").into_inner(), State::Data(new(DEFAULT, b""), &b"abc"[..]));
+        assert_eq!(string(new(DEFAULT, b"abc"), b"abcd").into_inner(), State::Incomplete(1));
+        assert_eq!(string(new(DEFAULT, b"abc"), b"abcde").into_inner(), State::Incomplete(2));
+        assert_eq!(string(new(DEFAULT, b"abc"), b"ac").into_inner(), State::Error(b"bc", err::expected(b'b')));
+
+        assert_eq!(string(new(END_OF_INPUT, b"abc"), b"a").into_inner(), State::Data(new(END_OF_INPUT, b"bc"), &b"a"[..]));
+        assert_eq!(string(new(END_OF_INPUT, b"abc"), b"ab").into_inner(), State::Data(new(END_OF_INPUT, b"c"), &b"ab"[..]));
+        assert_eq!(string(new(END_OF_INPUT, b"abc"), b"abc").into_inner(), State::Data(new(END_OF_INPUT, b""), &b"abc"[..]));
+        assert_eq!(string(new(END_OF_INPUT, b"abc"), b"abcd").into_inner(), State::Incomplete(1));
+        assert_eq!(string(new(END_OF_INPUT, b"abc"), b"abcde").into_inner(), State::Incomplete(2));
+        assert_eq!(string(new(END_OF_INPUT, b"abc"), b"ac").into_inner(), State::Error(b"bc", err::expected(b'b')));
+    }
 }

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,16 +1,14 @@
 //! Basic parsers.
 
 use std::mem;
-use std::any;
-use std::error;
-use std::fmt;
-
-#[cfg(feature="noop_error")]
-use std::marker::PhantomData;
 
 use input::Input;
 use parse_result::SimpleResult;
 use primitives::InputBuffer;
+
+pub use self::error::Error;
+#[cfg(all(not(feature="noop_error"), feature="backtrace"))]
+pub use self::error::StackFrame;
 
 /// Matches any item, returning it if present.
 ///
@@ -405,137 +403,340 @@ pub fn eof<I>(i: Input<I>) -> SimpleResult<I, ()> {
     }
 }
 
-/// Common error for the basic Chomp parsers.
-///
-/// This is the common error for the basic Chomp parsers. It will contain information about what a
-/// parser expected or if it encountered something unexpected (in the case of user supplied
-/// predicates, eg. `satisfy`).
-///
-/// This is coupled with the state found in the error state of the `ParseResult` type.
-#[cfg(not(feature="noop_error"))]
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct Error<I> {
-    /// `Some(T)` if it expected a specific token, `None` if it encountered something unexpected.
-    expected: Option<I>,
+#[cfg(not(any(feature="noop_error", feature="backtrace")))]
+mod error {
+    use std::any;
+    use std::error;
+    use std::fmt;
+
+    /// Common error for the basic Chomp parsers.
+    ///
+    /// This is the common error for the basic Chomp parsers. It will contain information about what a
+    /// parser expected or if it encountered something unexpected (in the case of user supplied
+    /// predicates, eg. `satisfy`).
+    ///
+    /// This is coupled with the state found in the error state of the `ParseResult` type.
+    #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    pub struct Error<I> {
+        /// `Some(T)` if it expected a specific token, `None` if it encountered something unexpected.
+        expected: Option<I>,
+    }
+
+    impl<I: fmt::Debug> fmt::Debug for Error<I> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match self.expected {
+                Some(ref c) => write!(f, "Error(Expected({:?}))", c),
+                None        => write!(f, "Error(Unexpected)"),
+            }
+        }
+    }
+
+    impl<I> Error<I> {
+        /// Creates a new Unexpected error.
+        ///
+        /// Should be used when the error value is not important.
+        #[inline(always)]
+        pub fn new() -> Self {
+            Error {
+                expected: None,
+            }
+        }
+
+        /// Creates a new Unexpected error.
+        ///
+        /// Should be used when the token was unexpected, as in the case of `satisfy` where a user
+        /// provided predicate is provided.
+        #[inline(always)]
+        pub fn unexpected() -> Self {
+            Error {
+                expected: None,
+            }
+        }
+
+        /// Creates a new Expected error.
+        ///
+        /// Should be used when a specific token was expected.
+        #[inline(always)]
+        pub fn expected(i: I) -> Self {
+            Error {
+                expected: Some(i),
+            }
+        }
+
+        /// Returns `Some(&I)` if a specific token was expected, `None` otherwise.
+        #[inline]
+        pub fn expected_token(&self) -> Option<&I> {
+            self.expected.as_ref()
+        }
+    }
+
+    impl<I> fmt::Display for Error<I>
+      where I: fmt::Debug {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match self.expected.as_ref() {
+                Some(ref c) => write!(f, "expected {:?}", *c),
+                None        => write!(f, "unexpected"),
+            }
+        }
+    }
+
+    impl<I: any::Any + fmt::Debug> error::Error for Error<I> {
+        fn description(&self) -> &str {
+            match self.expected.as_ref() {
+                Some(_) => "expected a certain token, received another",
+                None    => "received an unexpected token",
+            }
+        }
+    }
 }
 
-#[cfg(not(feature="noop_error"))]
-impl<I> Error<I> {
-    /// Creates a new Unexpected error.
+#[cfg(all(not(feature="noop_error"), feature="backtrace"))]
+mod error {
+    use std::any;
+    use std::error;
+    use std::fmt;
+    use std::os::raw;
+    use std::ops;
+    use std::borrow::Cow;
+
+    use backtrace;
+
+    /// Common error for the basic Chomp parsers. `backtrace` enabled.
     ///
-    /// Should be used when the error value is not important.
-    #[inline(always)]
-    pub fn new() -> Self {
-        Error {
-            expected: None,
-        }
-    }
-
-    /// Creates a new Unexpected error.
+    /// This is the common error for the basic Chomp parsers. It will contain information about what a
+    /// parser expected or if it encountered something unexpected (in the case of user supplied
+    /// predicates, eg. `satisfy`).
     ///
-    /// Should be used when the token was unexpected, as in the case of `satisfy` where a user
-    /// provided predicate is provided.
-    #[inline(always)]
-    pub fn unexpected() -> Self {
-        Error {
-            expected: None,
+    /// This is coupled with the state found in the error state of the `ParseResult` type.
+    #[derive(Clone, Ord, PartialOrd, Hash)]
+    pub struct Error<I> {
+        /// `Some(T)` if it expected a specific token, `None` if it encountered something unexpected.
+        expected: Option<I>,
+        trace:    Vec<*mut raw::c_void>,
+    }
+
+    impl<I: PartialEq> PartialEq<Error<I>> for Error<I> {
+        fn eq(&self, other: &Error<I>) -> bool {
+            self.expected == other.expected
         }
     }
 
-    /// Creates a new Expected error.
+    impl<I: Eq> Eq for Error<I> {}
+
+    impl<I: fmt::Debug> fmt::Debug for Error<I> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match self.expected {
+                Some(ref c) => try!(write!(f, "Error(Expected({:?}), \n", c)),
+                None        => try!(write!(f, "Error(Unexpected, \n")),
+            }
+
+            for frame in self.trace().into_iter() {
+                // TODO: is there any nicer way to get a decent indent?
+                try!(write!(f, "    "));
+                try!(fmt::Debug::fmt(&frame, f));
+                try!(write!(f, "\n"));
+            }
+
+            write!(f, ")")
+        }
+    }
+
+    /// A stack frame with information gathered from the runtime.
     ///
-    /// Should be used when a specific token was expected.
-    #[inline(always)]
-    pub fn expected(i: I) -> Self {
-        Error {
-            expected: Some(i),
+    /// See notes from the `backtrace` crate about when this information might and might not be
+    /// available.
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct StackFrame {
+        /// Instruction pointer
+        pub ip:   *mut raw::c_void,
+        /// Function name if found
+        pub name: Option<String>,
+        /// Address
+        pub addr: Option<*mut raw::c_void>,
+        /// Source file name
+        pub file: Option<String>,
+        /// Source line number
+        pub line: Option<u32>,
+    }
+
+    impl fmt::Debug for StackFrame {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            let n = self.line.map(|n| Cow::Owned(format!("{}", n)))
+                .unwrap_or(Cow::Borrowed("<unknown>"));
+
+            write!(f, "{:16p} - {} ({}:{})",
+                self.ip,
+                self.name.as_ref().map(ops::Deref::deref).unwrap_or("<unknown>"),
+                self.file.as_ref().map(ops::Deref::deref).unwrap_or("<unknown>"),
+                n,
+                )
         }
     }
 
-    /// Returns `Some(&I)` if a specific token was expected, `None` otherwise.
-    pub fn expected_token(&self) -> Option<&I> {
-        self.expected.as_ref()
-    }
-}
+    macro_rules! new_trace {
+        () => { {
+            let mut v = Vec::new();
 
-#[cfg(not(feature="noop_error"))]
-impl<I> fmt::Display for Error<I>
-  where I: fmt::Debug {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self.expected.as_ref() {
-            Some(ref c) => write!(f, "expected {:?}", *c),
-            None        => write!(f, "unexpected"),
+            backtrace::trace(&mut |frame| {
+                v.push(frame.ip());
+
+                true
+            });
+
+            v
+        } }
+    }
+
+    impl<I> Error<I> {
+        /// Creates a new Unexpected error.
+        ///
+        /// Should be used when the error value is not important.
+        #[inline(always)]
+        pub fn new() -> Self {
+            Error {
+                expected: None,
+                trace:    new_trace!(),
+            }
+        }
+
+        /// Creates a new Unexpected error.
+        ///
+        /// Should be used when the token was unexpected, as in the case of `satisfy` where a user
+        /// provided predicate is provided.
+        #[inline(always)]
+        pub fn unexpected() -> Self {
+            Error {
+                expected: None,
+                trace:    new_trace!(),
+            }
+        }
+
+        /// Creates a new Expected error.
+        ///
+        /// Should be used when a specific token was expected.
+        #[inline(always)]
+        pub fn expected(i: I) -> Self {
+            Error {
+                expected: Some(i),
+                trace:    new_trace!(),
+            }
+        }
+
+        /// Returns `Some(&I)` if a specific token was expected, `None` otherwise.
+        #[inline]
+        pub fn expected_token(&self) -> Option<&I> {
+            self.expected.as_ref()
+        }
+
+        /// Returns a stack-trace to where the error was created.
+        pub fn trace(&self) -> Vec<StackFrame> {
+            self.trace.iter().map(|&ip| {
+                let mut f = StackFrame { ip: ip, name: None, addr: None, file: None, line: None };
+
+                backtrace::resolve(ip, &mut |sym| {
+                    f.name = sym.name().map(String::from_utf8_lossy).map(|mangled| {
+                        let mut name = String::new();
+
+                        match backtrace::demangle(&mut name, &mangled) {
+                            Ok(()) => name,
+                            Err(_) => mangled.into_owned(),
+                        }
+                    });
+                    f.addr = sym.addr();
+                    f.file = sym.filename().map(String::from_utf8_lossy).map(Cow::into_owned);
+                    f.line = sym.lineno();
+                });
+
+                f
+            }).collect()
         }
     }
-}
 
-#[cfg(not(feature="noop_error"))]
-impl<I: any::Any + fmt::Debug> error::Error for Error<I> {
-    fn description(&self) -> &str {
-        match self.expected.as_ref() {
-            Some(_) => "expected a certain token, received another",
-            None    => "received an unexpected token",
+    impl<I> fmt::Display for Error<I>
+      where I: fmt::Debug {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match self.expected.as_ref() {
+                Some(ref c) => write!(f, "expected {:?}", *c),
+                None        => write!(f, "unexpected"),
+            }
+        }
+    }
+
+    impl<I: any::Any + fmt::Debug> error::Error for Error<I> {
+        fn description(&self) -> &str {
+            match self.expected.as_ref() {
+                Some(_) => "expected a certain token, received another",
+                None    => "received an unexpected token",
+            }
         }
     }
 }
 
 #[cfg(feature="noop_error")]
-#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
-pub struct Error<I> {
-    _i: PhantomData<I>,
-}
+mod error {
+    use std::any;
+    use std::error;
+    use std::fmt;
+    use std::marker::PhantomData;
 
-#[cfg(feature="noop_error")]
-impl<I> Error<I> {
-    /// Creates a new Unexpected error.
+    /// Common error for the basic Chomp parsers. `noop_error` enabled.
     ///
-    /// Should be used when the error value is not important.
-    #[inline(always)]
-    pub fn new() -> Self {
-        Error {
-            _i: PhantomData,
+    /// This is the common error for the basic Chomp parsers. It is an empty type signalling that a
+    /// parser failed at the location specified in the error state from `ParseResult`.
+    #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+    pub struct Error<I> {
+        _i: PhantomData<I>,
+    }
+
+    impl<I> Error<I> {
+        /// Creates a new Unexpected error.
+        ///
+        /// Should be used when the error value is not important.
+        #[inline(always)]
+        pub fn new() -> Self {
+            Error {
+                _i: PhantomData,
+            }
+        }
+
+        /// Creates a new Unexpected error.
+        ///
+        /// Should be used when the token was unexpected, as in the case of `satisfy` where a user
+        /// provided predicate is provided.
+        #[inline(always)]
+        pub fn unexpected() -> Self {
+            Error {
+                _i: PhantomData,
+            }
+        }
+
+        /// Creates a new Expected error.
+        ///
+        /// Should be used when a specific token was expected.
+        #[inline(always)]
+        pub fn expected(_i: I) -> Self {
+            Error {
+                _i: PhantomData,
+            }
+        }
+
+        /// Always returns `None` since the feature `noop_error` is enabled.
+        pub fn expected_token(&self) -> Option<&I> {
+            None
         }
     }
 
-    /// Creates a new Unexpected error.
-    ///
-    /// Should be used when the token was unexpected, as in the case of `satisfy` where a user
-    /// provided predicate is provided.
-    #[inline(always)]
-    pub fn unexpected() -> Self {
-        Error {
-            _i: PhantomData,
+    impl<I> fmt::Display for Error<I>
+      where I: fmt::Debug {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            write!(f, "parse error")
         }
     }
 
-    /// Creates a new Expected error.
-    ///
-    /// Should be used when a specific token was expected.
-    #[inline(always)]
-    pub fn expected(_i: I) -> Self {
-        Error {
-            _i: PhantomData,
+    impl<I: any::Any + fmt::Debug> error::Error for Error<I> {
+        fn description(&self) -> &str {
+            &"parse error"
         }
-    }
-
-    /// Always returns none.
-    pub fn expected_token(&self) -> Option<&I> {
-        None
-    }
-}
-
-#[cfg(feature="noop_error")]
-impl<I> fmt::Display for Error<I>
-  where I: fmt::Debug {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "parse error")
-    }
-}
-
-#[cfg(feature="noop_error")]
-impl<I: any::Any + fmt::Debug> error::Error for Error<I> {
-    fn description(&self) -> &str {
-        &"parse error"
     }
 }
 
@@ -687,5 +888,16 @@ mod test {
         assert_eq!(e.expected_token(), None);
         let e = Error::expected(b'a');
         assert_eq!(e.expected_token(), None);
+    }
+
+    #[test]
+    #[cfg(feature="backtrace")]
+    fn backtrace_test() {
+        let e = Error::<()>::new();
+
+        let trace = e.trace();
+        let frame = trace.iter().find(|frame| frame.name.as_ref().map(|n| n.starts_with("parsers::test::backtrace_test")).unwrap_or(false));
+
+        assert!(frame.is_some());
     }
 }

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -702,7 +702,7 @@ mod test {
 
     #[test]
     #[cfg(feature = "noop_error")]
-    fn error_test() {
+    fn noop_error_test() {
         let e = Error::<()>::new();
         assert_eq!(e.expected_token(), None);
         let e = Error::<()>::unexpected();
@@ -719,6 +719,6 @@ mod test {
         let trace = e.trace();
         let this  = &trace[0];
 
-        assert!(this.name.as_ref().map(|n| n.starts_with("parsers::test::backtrace_test")).unwrap_or(false));
+        assert!(this.name.as_ref().map(|n| n.starts_with("parsers::test::backtrace_test")).unwrap_or(false), "Expected trace to start with \"parsers::test::backtrace_test\", got: {:?}", this.name.as_ref());
     }
 }


### PR DESCRIPTION
Fixes #15 and #23 

Does seem to have some pretty decent performance-improvements in general when comparing to master (293994c7bc8b1cdd0f9ab13b9295f6438422d0e9) using `verbose_error`:

This branch (317f2ca5312ec69c83c55bf5b6ae11b920901139):
```
     Running target/release/combinators-2e7b66495b16e58a

running 6 tests
test count_vec_10k ... bench:      12,994 ns/iter (+/- 333)
test count_vec_1k  ... bench:       1,361 ns/iter (+/- 69)
test many1_vec_10k ... bench:      23,901 ns/iter (+/- 10,821)
test many1_vec_1k  ... bench:       2,792 ns/iter (+/- 286)
test many_vec_10k  ... bench:      21,778 ns/iter (+/- 6,702)
test many_vec_1k   ... bench:       2,449 ns/iter (+/- 183)

test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured

     Running target/release/http_bench-0586c66d0d734e56

running 4 tests
test multiple_requests      ... bench:      51,415 ns/iter (+/- 13,400)
test single_request         ... bench:         707 ns/iter (+/- 47)
test single_request_large   ... bench:       1,122 ns/iter (+/- 114)
test single_request_minimal ... bench:         131 ns/iter (+/- 12)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured
```

master using `verbose_error`:

```
     Running target/release/combinators-2e7b66495b16e58a

running 6 tests
test count_vec_10k ... bench:     132,497 ns/iter (+/- 2,177)
test count_vec_1k  ... bench:      13,558 ns/iter (+/- 913)
test many1_vec_10k ... bench:     133,911 ns/iter (+/- 21,261)
test many1_vec_1k  ... bench:      13,912 ns/iter (+/- 3,692)
test many_vec_10k  ... bench:     131,241 ns/iter (+/- 15,787)
test many_vec_1k   ... bench:      13,609 ns/iter (+/- 1,336)

test result: ok. 0 passed; 0 failed; 0 ignored; 6 measured

     Running target/release/http_bench-0586c66d0d734e56

running 4 tests
test multiple_requests      ... bench:      62,534 ns/iter (+/- 1,925)
test single_request         ... bench:         888 ns/iter (+/- 165)
test single_request_large   ... bench:       1,324 ns/iter (+/- 662)
test single_request_minimal ... bench:         180 ns/iter (+/- 14)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured
```

Seems like the tight loops in the combinators benchmark are especially improved by this change (probably since `parsers::Error` does not need a `Drop` implementation).