### PR TITLE
Wrap macro expansion in parentheses

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -450,9 +450,9 @@ macro_rules! __parse_internal {
     // The four versions are needed to allow the empty case (no tailing allowed on the empty
     // case), _, $pat and $ident:$ty.
     ( @BIND(($input:expr ; _)                         $($exp:tt)+) )              => { __parse_internal!{@EXPR($input;) $($exp)* } };
-    ( @BIND(($input:expr ; _)                         $($exp:tt)+) $($tail:tt)+ ) => { __parse_internal!{@EXPR($input;) $($exp)* }.bind(|i, _| __parse_internal!{i; $($tail)* }) };
-    ( @BIND(($input:expr ; $name:pat)                 $($exp:tt)+) $($tail:tt)+ ) => { __parse_internal!{@EXPR($input;) $($exp)* }.bind(|i, $name| __parse_internal!{i; $($tail)* }) };
-    ( @BIND(($input:expr ; $name:ident : $name_ty:ty) $($exp:tt)+) $($tail:tt)+ ) => { __parse_internal!{@EXPR($input;) $($exp)* }.bind(|i, $name : $name_ty| __parse_internal!{i; $($tail)* }) };
+    ( @BIND(($input:expr ; _)                         $($exp:tt)+) $($tail:tt)+ ) => { (__parse_internal!{@EXPR($input;) $($exp)* }).bind(|i, _| __parse_internal!{i; $($tail)* }) };
+    ( @BIND(($input:expr ; $name:pat)                 $($exp:tt)+) $($tail:tt)+ ) => { (__parse_internal!{@EXPR($input;) $($exp)* }).bind(|i, $name| __parse_internal!{i; $($tail)* }) };
+    ( @BIND(($input:expr ; $name:ident : $name_ty:ty) $($exp:tt)+) $($tail:tt)+ ) => { (__parse_internal!{@EXPR($input;) $($exp)* }).bind(|i, $name : $name_ty| __parse_internal!{i; $($tail)* }) };
 
     // Term ::= Ret
     //        | Err


### PR DESCRIPTION
This is needed since there are changes to how macros are expanded on rust nightly which resulted in these errors:

```
<chomp macros>:5:59: 5:60 error: expected expression, found `.`
<chomp macros>:5 __parse_internal ! { @ EXPR ( $ input ; ) $ ( $ exp ) * } . bind (
                                                                           ^
<chomp macros>:9:59: 9:60 error: expected expression, found `.`
<chomp macros>:9 __parse_internal ! { @ EXPR ( $ input ; ) $ ( $ exp ) * } . bind (
                                                                           ^
<chomp macros>:5:59: 5:60 error: expected expression, found `.`
<chomp macros>:5 __parse_internal ! { @ EXPR ( $ input ; ) $ ( $ exp ) * } . bind (
                                                                           ^
<chomp macros>:9:59: 9:60 error: expected expression, found `.`
<chomp macros>:9 __parse_internal ! { @ EXPR ( $ input ; ) $ ( $ exp ) * } . bind (
                                                                           ^
<chomp macros>:9:59: 9:60 error: expected expression, found `.`
<chomp macros>:9 __parse_internal ! { @ EXPR ( $ input ; ) $ ( $ exp ) * } . bind (
```

-----

See: https://github.com/rust-lang/rust/issues/34543#issuecomment-230934521