### PR TITLE
Support for `no_std`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `std` feature which is enabled by default. Disabling this feature will result in a `no_std`-compatible
+  version of Chomp.
 - `ascii::float` parses a floating-point number with optional sign, fraction and exponent.
 - `combinators::choice` which attempts multiple heterogenous parsers from an iterator until one succeeds.
 - `parsers::skip_while1` skips at least one token matching a predicate.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,11 @@ compiletest_rs = { version = "0.2.1", optional = true }
 clippy         = { version = ">0.0.1", optional = true }
 
 [features]
-# Feature for running extra (compiletime fail) tests on nightly
-unstable      = ["compiletest_rs"]
+core          = []
 noop_error    = []
 backtrace     = ["debugtrace/backtrace"]
+# Feature for running extra (compiletime fail) tests on nightly
+unstable      = ["compiletest_rs"]
 
 # Feature for travis, so that both noop_error and backtrace can be enabled simultaneously
 # without causing parse-errors in the argument parser in travis-cargo.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ rustc_version = { version = "0.1.7" }
 
 [features]
 core          = []
-noop_error    = []
 backtrace     = ["debugtrace/backtrace"]
+noop_error    = []
 # Feature for running extra (compiletime fail) tests on nightly
 unstable      = ["compiletest_rs"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,10 @@ clippy         = { version = ">0.0.1", optional = true }
 rustc_version = { version = "0.1.7" }
 
 [features]
-core          = []
 backtrace     = ["debugtrace/backtrace"]
+default       = ["std"]
 noop_error    = []
+std           = []
 # Feature for running extra (compiletime fail) tests on nightly
 unstable      = ["compiletest_rs"]
 

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -179,7 +179,7 @@ pub trait Float<B: Buffer<Token=u8>>: Sized {
 }
 
 /// Only use the generic `Float` impl if we can rely on `Vec`.
-#[cfg(not(feature="core"))]
+#[cfg(feature="std")]
 mod float_impl {
     use std::str;
 
@@ -243,9 +243,9 @@ mod float_impl {
 
 /// Internal module containing specialized implementations of `Float` for `&[u8]`-buffers, used
 /// when `has_specialization` is on since we can enable the unstable `specialization` feature.
-/// We also use this when using `core` since the default implementation is not provided since it
+/// We also use this when not using `std` since the default implementation is not provided since it
 /// relies on `Vec`.
-#[cfg(any(has_specialization, feature="core"))]
+#[cfg(any(has_specialization, not(feature="std")))]
 mod float_impl_specialized {
     use std::str;
 

--- a/src/ascii.rs
+++ b/src/ascii.rs
@@ -178,6 +178,8 @@ pub trait Float<B: Buffer<Token=u8>>: Sized {
     unsafe fn parse_buffer<I: Input<Token=u8, Buffer=B>>(i: I, b: B) -> SimpleResult<I, Self>;
 }
 
+/// Only use the generic `Float` impl if we can rely on `Vec`.
+#[cfg(not(feature="core"))]
 mod float_impl {
     use std::mem::transmute;
 
@@ -241,7 +243,9 @@ mod float_impl {
 
 /// Internal module containing specialized implementations of `Float` for `&[u8]`-buffers, used
 /// when `has_specialization` is on since we can enable the unstable `specialization` feature.
-#[cfg(has_specialization)]
+/// We also use this when using `core` since the default implementation is not provided since it
+/// relies on `Vec`.
+#[cfg(any(has_specialization, feature="core"))]
 mod float_impl_specialized {
     use std::mem::transmute;
 

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -158,7 +158,7 @@ pub fn either<I, T, U, E, F, G>(i: I, f: F, g: G) -> ParseResult<I, Either<T, U>
 /// ];
 /// assert_eq!(parse_only(|i| choice(i, v), &b"c"[..]), Err((&b"c"[..], Error::expected(b'a'))));
 /// ```
-#[cfg(not(feature="core"))]
+#[cfg(feature="std")]
 #[inline]
 pub fn choice<I, T, E, R>(mut i: I, parsers: R) -> ParseResult<I, T, E>
   where I: Input,
@@ -610,7 +610,7 @@ mod test {
         assert_eq!(look_ahead(&b"aa"[..], |i| token(i, b'a').then(|i| token(i, b'b')).map_err(|_| "err")).into_inner(), (&b"aa"[..], Err("err")));
     }
 
-    #[cfg(not(feature="core"))]
+    #[cfg(feature="std")]
     mod choice_tests {
         use combinators::choice;
         use parsers::{Error, token};

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -158,6 +158,7 @@ pub fn either<I, T, U, E, F, G>(i: I, f: F, g: G) -> ParseResult<I, Either<T, U>
 /// ];
 /// assert_eq!(parse_only(|i| choice(i, v), &b"c"[..]), Err((&b"c"[..], Error::expected(b'a'))));
 /// ```
+#[cfg(not(feature="core"))]
 #[inline]
 pub fn choice<I, T, E, R>(mut i: I, parsers: R) -> ParseResult<I, T, E>
   where I: Input,

--- a/src/combinators/mod.rs
+++ b/src/combinators/mod.rs
@@ -610,21 +610,28 @@ mod test {
         assert_eq!(look_ahead(&b"aa"[..], |i| token(i, b'a').then(|i| token(i, b'b')).map_err(|_| "err")).into_inner(), (&b"aa"[..], Err("err")));
     }
 
-    #[test]
-    fn choice_test() {
-        let v: Vec<Box<FnMut(_) -> _>> = vec![Box::new(|i| token(i, b'a')), Box::new(|i| token(i, b'b'))];
-        assert_eq!(choice(&b"abc"[..], v).into_inner(), (&b"bc"[..], Ok(b'a')));
+    #[cfg(not(feature="core"))]
+    mod choice_tests {
+        use combinators::choice;
+        use parsers::{Error, token};
+        use primitives::IntoInner;
 
-        let v: Vec<Box<FnMut(_) -> _>> = vec![Box::new(|i| token(i, b'a')), Box::new(|i| token(i, b'b'))];
-        assert_eq!(choice(&b"bca"[..], v).into_inner(), (&b"ca"[..], Ok(b'b')));
+        #[test]
+        fn choice_test() {
+            let v: Vec<Box<FnMut(_) -> _>> = vec![Box::new(|i| token(i, b'a')), Box::new(|i| token(i, b'b'))];
+            assert_eq!(choice(&b"abc"[..], v).into_inner(), (&b"bc"[..], Ok(b'a')));
 
-        let v: Vec<Box<FnMut(_) -> _>> = vec![Box::new(|i| token(i, b'a')), Box::new(|i| token(i, b'b'))];
-        assert_eq!(choice(&b"cab"[..], v).into_inner(), (&b"cab"[..], Err(Error::expected(b'b'))));
-    }
+            let v: Vec<Box<FnMut(_) -> _>> = vec![Box::new(|i| token(i, b'a')), Box::new(|i| token(i, b'b'))];
+            assert_eq!(choice(&b"bca"[..], v).into_inner(), (&b"ca"[..], Ok(b'b')));
 
-    #[test]
-    #[should_panic]
-    fn choice_empty() {
-        assert_eq!(choice::<_, (), (), _>(&b"abc"[..], vec![]).into_inner(), (&b"abc"[..], Err(())));
+            let v: Vec<Box<FnMut(_) -> _>> = vec![Box::new(|i| token(i, b'a')), Box::new(|i| token(i, b'b'))];
+            assert_eq!(choice(&b"cab"[..], v).into_inner(), (&b"cab"[..], Err(Error::expected(b'b'))));
+        }
+
+        #[test]
+        #[should_panic]
+        fn choice_empty() {
+            assert_eq!(choice::<_, (), (), _>(&b"abc"[..], vec![]).into_inner(), (&b"abc"[..], Err(())));
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@
 /// Skipped when using test since we use std for tests.
 #[cfg(all(feature = "core", not(test)))]
 mod std {
-    pub use core::{cell, cmp, fmt, iter, marker, mem, ops, ptr};
+    pub use core::{cell, cmp, fmt, iter, marker, mem, ops, ptr, str};
 }
 
 #[cfg(feature = "tendril")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,10 +236,12 @@
     single_match_else))]
 #![cfg_attr(feature="clippy", allow(inline_always, many_single_char_names))]
 
-#![cfg_attr(feature="core", no_std)]
+#![cfg_attr(all(feature="core", not(test)), no_std)]
 
 /// Inner module to emulate std when using `core`.
-#[cfg(feature = "core")]
+///
+/// Skipped when using test since we use std for tests.
+#[cfg(all(feature = "core", not(test)))]
 mod std {
     pub use core::{cell, cmp, fmt, iter, marker, mem, ops, ptr};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,13 +199,14 @@
 //!    The built-in `chomp::parsers::Error` type is zero-sized and carry no error-information. This
 //!    increases performance somewhat.
 //!
-//! * `core`:
-#![cfg_attr(not(feature="core"), doc = " disabled (default).")]
-#![cfg_attr(feature="core", doc = " enabled.")]
+//! * `std`:
+#![cfg_attr(not(feature="std"), doc = " disabled.")]
+#![cfg_attr(feature="std", doc = " enabled (default).")]
 //!
-//!    Chomp excludes all features which rely on Rust's `std` library, using the `no_std` feature.
+//!    Chomp includes all features which rely on Rust's `std` library. If this is diabled Chomp
+//!    will use the `no_std` feature, only using Rust's `core` library.
 //!
-//!    Excluded items:
+//!    Items excluded when `std` is disabled:
 //!
 //!     * `ascii::float` support for `type::Buffer` implementations other than `&[u8]`.
 //!     * `buffer` module.
@@ -236,17 +237,18 @@
     single_match_else))]
 #![cfg_attr(feature="clippy", allow(inline_always, many_single_char_names))]
 
-#![cfg_attr(all(feature="core", not(test)), no_std)]
+// `std` is required for tests.
+#![cfg_attr(all(not(feature="std"), not(test)), no_std)]
 
-/// Inner module to emulate std when using `core`.
+/// Inner module to emulate std when using the `core` crate.
 ///
 /// Skipped when using test since we use std for tests.
-#[cfg(all(feature = "core", not(test)))]
+#[cfg(all(not(feature="std"), not(test)))]
 mod std {
     pub use core::{cell, cmp, fmt, iter, marker, mem, ops, ptr, str};
 }
 
-#[cfg(feature = "tendril")]
+#[cfg(feature="tendril")]
 extern crate tendril;
 
 #[macro_use]
@@ -262,7 +264,7 @@ mod parse;
 pub mod ascii;
 // TODO: Rework buffer module so that at least a part of it can be exposed provided the user
 // provides their own buffers allocated from outside.
-#[cfg(not(feature="core"))]
+#[cfg(feature="std")]
 pub mod buffer;
 pub mod combinators;
 pub mod parsers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,14 @@
     single_match_else))]
 #![cfg_attr(feature="clippy", allow(inline_always, many_single_char_names))]
 
+#![cfg_attr(feature="core", no_std)]
+
+/// Inner module to emulate std when using `core`.
+#[cfg(feature = "core")]
+mod std {
+    pub use core::{cell, cmp, fmt, iter, marker, mem, ops, ptr};
+}
+
 #[cfg(feature = "tendril")]
 extern crate tendril;
 
@@ -233,7 +241,9 @@ mod macros;
 mod parse;
 
 pub mod ascii;
-pub mod buffer;
+// FIXME: Import but make it compatible with core by exposing a minimal buffer-helper which doesn't
+// require std
+//pub mod buffer;
 pub mod combinators;
 pub mod parsers;
 pub mod primitives;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,21 @@
 //!
 //!    The built-in `chomp::parsers::Error` type is zero-sized and carry no error-information. This
 //!    increases performance somewhat.
+//!
+//! * `core`:
+#![cfg_attr(not(feature="core"), doc = " disabled (default).")]
+#![cfg_attr(feature="core", doc = " enabled.")]
+//!
+//!    Chomp excludes all features which rely on Rust's `std` library, using the `no_std` feature.
+//!
+//!    Excluded items:
+//!
+//!     * `ascii::float` support for `type::Buffer` implementations other than `&[u8]`.
+//!     * `buffer` module.
+//!     * `combinators::choice` combinator.
+//!     * `parsers::Error` no longer implements the `std::error::Error` trait.
+//!     * `types::Buffer::to_vec`
+//!     * `types::Buffer::into_vec`
 
 #![warn(missing_docs,
         missing_debug_implementations,
@@ -243,9 +258,10 @@ mod macros;
 mod parse;
 
 pub mod ascii;
-// FIXME: Import but make it compatible with core by exposing a minimal buffer-helper which doesn't
-// require std
-//pub mod buffer;
+// TODO: Rework buffer module so that at least a part of it can be exposed provided the user
+// provides their own buffers allocated from outside.
+#[cfg(not(feature="core"))]
+pub mod buffer;
 pub mod combinators;
 pub mod parsers;
 pub mod primitives;

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -418,9 +418,9 @@ pub fn eof<I: Input>(mut i: I) -> SimpleResult<I, ()> {
 }
 
 mod error {
-    #[cfg(not(feature = "core"))]
+    #[cfg(feature="std")]
     use std::any;
-    #[cfg(not(feature = "core"))]
+    #[cfg(feature="std")]
     use std::error;
     use std::fmt;
 
@@ -498,7 +498,7 @@ mod error {
     }
 
     #[cfg(feature="noop_error")]
-    #[cfg(not(feature = "core"))]
+    #[cfg(feature="std")]
     impl<I: any::Any + fmt::Debug> error::Error for Error<I> {
         fn description(&self) -> &str {
             &"parse error"
@@ -506,7 +506,7 @@ mod error {
     }
 
     #[cfg(not(feature="noop_error"))]
-    #[cfg(not(feature = "core"))]
+    #[cfg(feature="std")]
     impl<I: any::Any + fmt::Debug> error::Error for Error<I> {
         fn description(&self) -> &str {
             match self.0.as_ref() {

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -402,7 +402,9 @@ pub fn eof<I: Input>(mut i: I) -> SimpleResult<I, ()> {
 }
 
 mod error {
+    #[cfg(not(feature = "core"))]
     use std::any;
+    #[cfg(not(feature = "core"))]
     use std::error;
     use std::fmt;
 
@@ -480,6 +482,7 @@ mod error {
     }
 
     #[cfg(feature="noop_error")]
+    #[cfg(not(feature = "core"))]
     impl<I: any::Any + fmt::Debug> error::Error for Error<I> {
         fn description(&self) -> &str {
             &"parse error"
@@ -487,6 +490,7 @@ mod error {
     }
 
     #[cfg(not(feature="noop_error"))]
+    #[cfg(not(feature = "core"))]
     impl<I: any::Any + fmt::Debug> error::Error for Error<I> {
         fn description(&self) -> &str {
             match self.0.as_ref() {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -816,7 +816,7 @@ pub mod test {
         use primitives::Primitives;
 
         fn buffer_eq_slice<B: Buffer + Clone, F: Fn(u8) -> B::Token>(b: B, s: &[u8], f: F)
-          where B::Token: Debug, {
+          where B::Token: Debug {
             assert_eq!(b.len(), s.len());
             assert_eq!(b.is_empty(), s.is_empty());
             assert_eq!(b.clone().fold(0, |n, c| {
@@ -824,8 +824,18 @@ pub mod test {
 
                 n + 1
             }), s.iter().count());
+            buffer_to_vec(b, s, f);
+        }
+
+        #[cfg(not(feature="core"))]
+        fn buffer_to_vec<B: Buffer + Clone, F: Fn(u8) -> B::Token>(b: B, s: &[u8], f: F)
+          where B::Token: Debug {
             assert_eq!(b.to_vec(), s.iter().cloned().map(f).collect::<Vec<_>>());
         }
+
+        #[cfg(feature="core")]
+        fn buffer_to_vec<B: Buffer + Clone, F: Fn(u8) -> B::Token>(_: B, _: &[u8], _: F)
+          where B::Token: Debug {}
 
         let m = s.mark();
         assert_eq!(s.peek(), Some(f(b'a')));

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -36,14 +36,14 @@ pub trait Buffer: PartialEq<Self> {
     fn len(&self) -> usize;
 
     /// Copies all the tokens in this buffer to a new `Vec`.
-    #[cfg(not(feature = "core"))]
+    #[cfg(feature="std")]
     fn to_vec(&self) -> Vec<Self::Token>;
 
     /// Consumes self to create an owned vector of tokens.
     ///
     /// Will allocate if the implementation borrows storage or does not use an owned type
     /// compatible with `Vec` internally.
-    #[cfg(not(feature = "core"))]
+    #[cfg(feature="std")]
     fn into_vec(self) -> Vec<Self::Token>;
 
     /// Returns true if this buffer is empty.
@@ -72,12 +72,12 @@ impl<'a, I: Copy + PartialEq> Buffer for &'a [I] {
         (&self[..]).len()
     }
 
-    #[cfg(not(feature = "core"))]
+    #[cfg(feature="std")]
     fn to_vec(&self) -> Vec<Self::Token> {
         (&self[..]).to_vec()
     }
 
-    #[cfg(not(feature = "core"))]
+    #[cfg(feature="std")]
     fn into_vec(self) -> Vec<Self::Token> {
         (&self[..]).to_vec()
     }
@@ -106,12 +106,12 @@ impl<'a> Buffer for &'a str {
         (&self[..]).is_empty()
     }
 
-    #[cfg(not(feature = "core"))]
+    #[cfg(feature="std")]
     fn to_vec(&self) -> Vec<Self::Token> {
         (&self[..]).chars().collect()
     }
 
-    #[cfg(not(feature = "core"))]
+    #[cfg(feature="std")]
     fn into_vec(self) -> Vec<Self::Token> {
         (&self[..]).chars().collect()
     }
@@ -827,13 +827,13 @@ pub mod test {
             buffer_to_vec(b, s, f);
         }
 
-        #[cfg(not(feature="core"))]
+        #[cfg(feature="std")]
         fn buffer_to_vec<B: Buffer + Clone, F: Fn(u8) -> B::Token>(b: B, s: &[u8], f: F)
           where B::Token: Debug {
             assert_eq!(b.to_vec(), s.iter().cloned().map(f).collect::<Vec<_>>());
         }
 
-        #[cfg(feature="core")]
+        #[cfg(not(feature="std"))]
         fn buffer_to_vec<B: Buffer + Clone, F: Fn(u8) -> B::Token>(_: B, _: &[u8], _: F)
           where B::Token: Debug {}
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -36,12 +36,14 @@ pub trait Buffer: PartialEq<Self> {
     fn len(&self) -> usize;
 
     /// Copies all the tokens in this buffer to a new `Vec`.
+    #[cfg(not(feature = "core"))]
     fn to_vec(&self) -> Vec<Self::Token>;
 
     /// Consumes self to create an owned vector of tokens.
     ///
     /// Will allocate if the implementation borrows storage or does not use an owned type
     /// compatible with `Vec` internally.
+    #[cfg(not(feature = "core"))]
     fn into_vec(self) -> Vec<Self::Token>;
 
     /// Returns true if this buffer is empty.
@@ -70,10 +72,12 @@ impl<'a, I: Copy + PartialEq> Buffer for &'a [I] {
         (&self[..]).len()
     }
 
+    #[cfg(not(feature = "core"))]
     fn to_vec(&self) -> Vec<Self::Token> {
         (&self[..]).to_vec()
     }
 
+    #[cfg(not(feature = "core"))]
     fn into_vec(self) -> Vec<Self::Token> {
         (&self[..]).to_vec()
     }
@@ -102,10 +106,12 @@ impl<'a> Buffer for &'a str {
         (&self[..]).is_empty()
     }
 
+    #[cfg(not(feature = "core"))]
     fn to_vec(&self) -> Vec<Self::Token> {
         (&self[..]).chars().collect()
     }
 
+    #[cfg(not(feature = "core"))]
     fn into_vec(self) -> Vec<Self::Token> {
         (&self[..]).chars().collect()
     }

--- a/src/types/tendril.rs
+++ b/src/types/tendril.rs
@@ -102,12 +102,12 @@ impl Buffer for ByteTendril {
         self.len32() as usize
     }
 
-    #[cfg(not(feature = "core"))]
+    #[cfg(feature="std")]
     fn to_vec(&self) -> Vec<Self::Token> {
         (&self[..]).iter().cloned().collect()
     }
 
-    #[cfg(not(feature = "core"))]
+    #[cfg(feature="std")]
     fn into_vec(self) -> Vec<Self::Token> {
         (&self[..]).iter().cloned().collect()
     }

--- a/src/types/tendril.rs
+++ b/src/types/tendril.rs
@@ -102,10 +102,12 @@ impl Buffer for ByteTendril {
         self.len32() as usize
     }
 
+    #[cfg(not(feature = "core"))]
     fn to_vec(&self) -> Vec<Self::Token> {
         (&self[..]).iter().cloned().collect()
     }
 
+    #[cfg(not(feature = "core"))]
     fn into_vec(self) -> Vec<Self::Token> {
         (&self[..]).iter().cloned().collect()
     }


### PR DESCRIPTION
Support for using Chomp without Rust's standard library, instead relying solely on the `core` module.
- `types::Buffer::to_vec` and `types::Buffer::as_vec` will not be a part of Chomp when built with `core`.
- `buffer` module will require some refactoring to allow for usage without `std::io`, and the buffer for the fixed-buffer needs to be user-supplied (because we can't allocate ourselves). See https://github.com/whitequark/rust-log_buffer for a good example on how to use user-provided buffers.
- `parsers::Error` cannot implement `std::error::Error`
