### PR TITLE
Source: implement Write if contained stream is Write

### DIFF
--- a/src/buffer/mod.rs
+++ b/src/buffer/mod.rs
@@ -43,7 +43,7 @@ use types::Buffer as InputBuffer;
 use primitives::Guard;
 
 pub use self::slice::SliceStream;
-pub use self::data_source::DataSource;
+pub use self::data_source::{DataSource, RWDataSource};
 pub use self::stateful::Source;
 
 const DEFAULT_BUFFER_SIZE: usize = 6 * 1024;

--- a/src/buffer/stateful.rs
+++ b/src/buffer/stateful.rs
@@ -56,6 +56,22 @@ impl<R: io::Read, B: Buffer<u8>> Source<ReadDataSource<R>, B> {
     }
 }
 
+impl<RW: io::Read + io::Write> Source<RWDataSource<RW>, FixedSizeBuffer<u8>> {
+    /// Creates a new `Source` from `Read`+`Write` with the default `FixedSizeBuffer` settings.
+    #[inline]
+    pub fn new_rw(rwsource: RW) -> Self {
+        Self::with_buffer(RWDataSource::new(rwsource), FixedSizeBuffer::new())
+    }
+}
+
+impl<RW: io::Read + io::Write, B: Buffer<u8>> Source<RWDataSource<RW>, B> {
+    /// Creates a new `Source` from `Read`+`Write` and buffer instances.
+    #[inline]
+    pub fn from_read_write(source: RW, buffer: B) -> Self {
+        Self::with_buffer(RWDataSource::new(source), buffer)
+    }
+}
+
 impl<I: Iterator, B: Buffer<I::Item>> Source<IteratorDataSource<I>, B>
   where I::Item: Copy + PartialEq {
     /// Creates a new `Source` from `Iterator` and `Buffer` instances.

--- a/src/buffer/stateful.rs
+++ b/src/buffer/stateful.rs
@@ -6,6 +6,7 @@ use primitives::IntoInner;
 use buffer::{
     Buffer,
     DataSource,
+    RWDataSource,
     FixedSizeBuffer,
     InputBuf,
     Stream,
@@ -194,6 +195,17 @@ impl<S: DataSource<Item=u8>, B: Buffer<u8>> io::BufRead for Source<S, B> {
     #[inline]
     fn consume(&mut self, num: usize) {
         self.buffer.consume(num)
+    }
+}
+
+impl<RW: io::Read + io::Write, B: Buffer<u8>> io::Write for Source<RWDataSource<RW>, B> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.source.write(buf)
+    }
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.source.flush()
     }
 }
 


### PR DESCRIPTION
when `DataSource` is a network connection or other bi-directional stream that you need to communicate as well as to parse data from, it's necessary to have access to the underlying contained `Write` methods. as the `Source` struct is the owner of the stream struct at that point, it seems necessary to wrap the underlying methods and implement `Write` for `Source` if the contained `DataSource` is an instance of `Write`.

i didn't include any version number change in this, as chomp is still well below 1.0.0 it's even by SemVer guidelines entirely your call :-)