### PR TITLE
Fix dependency features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ include = [
 
 [dependencies]
 bitflags   = "0.8.2"
-conv       = { version = "0.3.3", default-features = false, features = ["std"] }
+conv       = { version = "0.3.3" }
 either     = { version = "1.1.0" }
 debugtrace = { version = "0.1.0" }
 tendril    = { version = "0.2.2", optional = true }
@@ -38,7 +38,7 @@ clippy         = { version = ">0.0.1", optional = true }
 rustc_version = { version = "0.2.1" }
 
 [features]
-backtrace     = ["debugtrace/backtrace"]
+backtrace     = []
 default       = ["std"]
 noop_error    = []
 std           = []


### PR DESCRIPTION
- conv 0.3.3 doesn't have an "std" feature. Version 0.3.4 has an "std" feature, but 1) it hasn't been released to crates.io 2) this is the only feature, and it's enabled by default.
- debugtrace doesn't have a "backrace" feature. It is a dependency, enabled unconditionally.